### PR TITLE
멤버 프로필 변경, 회원 가입 기능을 추가적으로 구현합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/domain/emailverification/service/EmailVerificationService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/emailverification/service/EmailVerificationService.java
@@ -68,8 +68,6 @@ public class EmailVerificationService {
         validateVerificationCode(code, emailVerification.getContent());
 
         emailVerification.changeCheckStatus();
-
-        emailVerificationRepository.save(emailVerification);
     }
 
     private static void validateEmailVerification(EmailVerification emailVerification, LocalDateTime current) {

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package org.devridge.api.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.member.dto.request.UpdateMemberProfileRequest;
 import org.devridge.api.domain.member.dto.request.ChangePasswordRequest;
 import org.devridge.api.domain.member.dto.request.CreateMemberRequest;
 import org.devridge.api.domain.member.dto.request.DeleteMemberRequest;
+import org.devridge.api.domain.member.dto.response.UpdateMemberResponse;
 import org.devridge.api.domain.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +35,15 @@ public class MemberController {
     @PatchMapping("/password")
     public ResponseEntity<Void> resetPassword(@RequestBody ChangePasswordRequest changePasswordRequest) {
         memberService.changePassword(changePasswordRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<UpdateMemberResponse> updateMember(
+            @PathVariable("memberId") Long memberId,
+            @Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest
+    ) {
+        UpdateMemberResponse result = memberService.updateMember(memberId, updateMemberRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package org.devridge.api.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.devridge.api.domain.member.dto.request.UpdateMemberProfileRequest;
-import org.devridge.api.domain.member.dto.request.ChangePasswordRequest;
-import org.devridge.api.domain.member.dto.request.CreateMemberRequest;
-import org.devridge.api.domain.member.dto.request.DeleteMemberRequest;
+import org.devridge.api.domain.member.dto.request.*;
 import org.devridge.api.domain.member.dto.response.UpdateMemberResponse;
 import org.devridge.api.domain.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -27,14 +24,20 @@ public class MemberController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteMember(@RequestBody DeleteMemberRequest memberRequest) {
+    public ResponseEntity<Void> deleteMember(@Valid @RequestBody DeleteMemberRequest memberRequest) {
         memberService.deleteMember(memberRequest);
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/reset-password")
+    public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest resetPasswordRequest) {
+        memberService.resetPassword(resetPasswordRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PatchMapping("/password")
-    public ResponseEntity<Void> resetPassword(@RequestBody ChangePasswordRequest changePasswordRequest) {
-        memberService.changePassword(changePasswordRequest);
+    public ResponseEntity<Void> updatePassword(@Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
+        memberService.updatePassword(changePasswordRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -38,12 +38,11 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping("/{memberId}")
+    @PatchMapping
     public ResponseEntity<UpdateMemberResponse> updateMember(
-            @PathVariable("memberId") Long memberId,
             @Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest
     ) {
-        UpdateMemberResponse result = memberService.updateMember(memberId, updateMemberRequest);
+        UpdateMemberResponse result = memberService.updateMember(updateMemberRequest);
         return ResponseEntity.ok().body(result);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -44,6 +44,6 @@ public class MemberController {
             @Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest
     ) {
         UpdateMemberResponse result = memberService.updateMember(memberId, updateMemberRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -2,7 +2,7 @@ package org.devridge.api.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.member.dto.request.*;
-import org.devridge.api.domain.member.dto.response.UpdateMemberResponse;
+import org.devridge.api.domain.member.dto.response.MemberResponse;
 import org.devridge.api.domain.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,8 +42,14 @@ public class MemberController {
     }
 
     @PatchMapping
-    public ResponseEntity<UpdateMemberResponse> updateMember(@Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest) {
-        UpdateMemberResponse result = memberService.updateMember(updateMemberRequest);
+    public ResponseEntity<Void> updateMember(@Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest) {
+        memberService.updateMember(updateMemberRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/details")
+    public ResponseEntity<MemberResponse> getMemberDetails(){
+        MemberResponse result = memberService.getMemberDetails();
         return ResponseEntity.ok().body(result);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -37,7 +37,6 @@ public class MemberController {
 
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
-        System.out.println("changePasswordRequest = " + changePasswordRequest);
         memberService.updatePassword(changePasswordRequest);
         return ResponseEntity.ok().build();
     }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/MemberController.java
@@ -37,14 +37,13 @@ public class MemberController {
 
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
+        System.out.println("changePasswordRequest = " + changePasswordRequest);
         memberService.updatePassword(changePasswordRequest);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping
-    public ResponseEntity<UpdateMemberResponse> updateMember(
-            @Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest
-    ) {
+    public ResponseEntity<UpdateMemberResponse> updateMember(@Valid @RequestBody UpdateMemberProfileRequest updateMemberRequest) {
         UpdateMemberResponse result = memberService.updateMember(updateMemberRequest);
         return ResponseEntity.ok().body(result);
     }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/OccupationController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/OccupationController.java
@@ -1,11 +1,14 @@
 package org.devridge.api.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.member.dto.response.OccupationInformation;
 import org.devridge.api.domain.member.service.OccupationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +18,8 @@ public class OccupationController {
     private final OccupationService occupationService;
 
     @GetMapping
-    public ResponseEntity<?> getAllOccupations(){
+    public ResponseEntity<List<OccupationInformation>> getAllOccupations(){
+        List<OccupationInformation> result = occupationService.getAllOccupations();
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/controller/OccupationController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/controller/OccupationController.java
@@ -1,0 +1,20 @@
+package org.devridge.api.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.member.service.OccupationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/occupations")
+public class OccupationController {
+
+    private final OccupationService occupationService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllOccupations(){
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ChangePasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ChangePasswordRequest.java
@@ -1,14 +1,12 @@
 package org.devridge.api.domain.member.dto.request;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
-@NoArgsConstructor
 public class ChangePasswordRequest {
 
     @NotBlank(message = "빈 패스워드를 입력할 수 없습니다.")

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ChangePasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ChangePasswordRequest.java
@@ -1,20 +1,18 @@
 package org.devridge.api.domain.member.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
+@NoArgsConstructor
 public class ChangePasswordRequest {
 
     @NotBlank(message = "빈 패스워드를 입력할 수 없습니다.")
     @Size(min = 8, max = 20, message = "패스워드는 8자 이상 20자 이하이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", message = "패스워드는 영문자 + 숫자 조합이어야 합니다.")
     private String password;
-
-    public ChangePasswordRequest(String password) {
-        this.password = password;
-    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
@@ -1,14 +1,10 @@
 package org.devridge.api.domain.member.dto.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.*;
 import java.util.List;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class CreateMemberRequest {
 

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
@@ -27,6 +27,9 @@ public class CreateMemberRequest {
     @NotBlank(message = "빈 닉네임을 입력할 수 없습니다.")
     private String nickname;
 
+    @NotBlank(message = "잘못된 입력입니다. 다시 입력해주세요.")
+    @Size(min = 5, max = 25, message = "잘못된 입력입니다. 다시 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z가-힣 ]*$", message = "잘못된 입력입니다. 다시 입력해주세요.")
     private String introduction;
 
     // TODO: 이미지 처리
@@ -35,6 +38,5 @@ public class CreateMemberRequest {
     private List<Long> skillIds;
 
     @NotNull(message = "직군 ID를 입력해주세요.")
-    @Size(min = 1, max = 1, message = "직군 ID는 1개의 값만 가져야 합니다.")
     private Long occupationId;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
@@ -4,10 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 import java.util.List;
 
 @NoArgsConstructor
@@ -32,10 +29,12 @@ public class CreateMemberRequest {
 
     private String introduction;
 
-    private List<Long> occupationIds;
-
     // TODO: 이미지 처리
     private String profileImageUrl;
 
     private List<Long> skillIds;
+
+    @NotNull(message = "직군 ID를 입력해주세요.")
+    @Size(min = 1, max = 1, message = "직군 ID는 1개의 값만 가져야 합니다.")
+    private Long occupationId;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
@@ -30,6 +30,11 @@ public class CreateMemberRequest {
     @NotBlank(message = "빈 닉네임을 입력할 수 없습니다.")
     private String nickname;
 
+    private String introduction;
+
+    private List<Long> occupationIds;
+
+    // TODO: 이미지 처리
     private String profileImageUrl;
 
     private List<Long> skillIds;

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/CreateMemberRequest.java
@@ -25,6 +25,8 @@ public class CreateMemberRequest {
     private String provider;
 
     @NotBlank(message = "빈 닉네임을 입력할 수 없습니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣 ]*$", message = "잘못된 입력입니다. 다시 입력해주세요.")
+    @Size(min = 3, max = 12, message = "닉네임은 (3~12) 글자 입니다.")
     private String nickname;
 
     @NotBlank(message = "잘못된 입력입니다. 다시 입력해주세요.")
@@ -35,8 +37,9 @@ public class CreateMemberRequest {
     // TODO: 이미지 처리
     private String profileImageUrl;
 
+    @Size(max = 5, message = "스킬셋은 최대 5개까지만 입력할 수 있습니다.")
     private List<Long> skillIds;
 
-    @NotNull(message = "직군 ID를 입력해주세요.")
+    @NotNull(message = "직군을 입력해주세요.")
     private Long occupationId;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/DeleteMemberRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/DeleteMemberRequest.java
@@ -1,13 +1,9 @@
 package org.devridge.api.domain.member.dto.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 public class DeleteMemberRequest {
 

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
@@ -1,7 +1,6 @@
 package org.devridge.api.domain.member.dto.request;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -9,7 +8,6 @@ import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
-@NoArgsConstructor
 public class ResetPasswordRequest {
 
     @NotBlank(message = "빈 이메일을 입력할 수 없습니다.")
@@ -20,9 +18,4 @@ public class ResetPasswordRequest {
     @Size(min = 8, max = 20, message = "패스워드는 8자 이상 20자 이하이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", message = "패스워드는 영문자 + 숫자 조합이어야 합니다.")
     private String password;
-
-    public ResetPasswordRequest(String email, String password) {
-        this.email = email;
-        this.password = password;
-    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
@@ -1,6 +1,7 @@
 package org.devridge.api.domain.member.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -8,6 +9,7 @@ import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
+@NoArgsConstructor
 public class ResetPasswordRequest {
 
     @NotBlank(message = "빈 이메일을 입력할 수 없습니다.")

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
@@ -2,19 +2,25 @@ package org.devridge.api.domain.member.dto.request;
 
 import lombok.Getter;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
-public class ChangePasswordRequest {
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "빈 이메일을 입력할 수 없습니다.")
+    @Email(message = "유효하지 않은 이메일 형식입니다.")
+    private String email;
 
     @NotBlank(message = "빈 패스워드를 입력할 수 없습니다.")
     @Size(min = 8, max = 20, message = "패스워드는 8자 이상 20자 이하이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", message = "패스워드는 영문자 + 숫자 조합이어야 합니다.")
     private String password;
 
-    public ChangePasswordRequest(String password) {
+    public ResetPasswordRequest(String email, String password) {
+        this.email = email;
         this.password = password;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/UpdateMemberProfileRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/UpdateMemberProfileRequest.java
@@ -1,0 +1,22 @@
+package org.devridge.api.domain.member.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+public class UpdateMemberProfileRequest {
+
+    // TODO: 이미지 처리
+    private String profileImageUrl;
+
+    @NotBlank(message = "잘못된 입력입니다. 다시 입력해주세요.")
+    @Size(min = 5, max = 25, message = "잘못된 입력입니다. 다시 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z가-힣 ]*$", message = "잘못된 입력입니다. 다시 입력해주세요.")
+    private String introduction;
+
+    private List<Long> skillIds;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/response/LoginResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/response/LoginResponse.java
@@ -1,7 +1,6 @@
 package org.devridge.api.domain.member.dto.response;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,11 +9,8 @@ import lombok.NoArgsConstructor;
 public class LoginResponse {
 
     private String accessToken;
-    private MemberResponse member;
 
-    @Builder
-    public LoginResponse(String accessToken, MemberResponse member) {
+    public LoginResponse(String accessToken) {
         this.accessToken = accessToken;
-        this.member = member;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/response/MemberResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/response/MemberResponse.java
@@ -16,13 +16,15 @@ public class MemberResponse {
     private String imageUrl;
     private String introduction;
     private List<Long> skillIds;
+    private String occupation;
 
     @Builder
-    public MemberResponse(Long id, String nickname, String imageUrl, String introduction, List<Long> skillIds) {
+    public MemberResponse(Long id, String nickname, String imageUrl, String introduction, List<Long> skillIds, String occupation) {
         this.id = id;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.introduction = introduction;
         this.skillIds = skillIds;
+        this.occupation = occupation;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/response/OccupationInformation.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/response/OccupationInformation.java
@@ -1,0 +1,15 @@
+package org.devridge.api.domain.member.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class OccupationInformation {
+
+    private Long id;
+    private String occupationName;
+
+    public OccupationInformation(Long id, String occupationName) {
+        this.id = id;
+        this.occupationName = occupationName;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/response/UpdateMemberResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/response/UpdateMemberResponse.java
@@ -1,0 +1,13 @@
+package org.devridge.api.domain.member.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateMemberResponse {
+
+    private MemberResponse member;
+
+    public UpdateMemberResponse(MemberResponse member) {
+        this.member = member;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
@@ -66,4 +66,9 @@ public class Member extends BaseEntity {
     public void changePassword(String encodePassword) {
         this.password = encodePassword;
     }
+
+    public void updateProfile(String profileImageUrl, String introduction) {
+        this.profileImageUrl = profileImageUrl;
+        this.introduction = introduction;
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
@@ -25,6 +25,7 @@ import java.util.List;
 @Where(clause = "is_deleted = false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
+
     @NotNull
     private String email;
 
@@ -58,7 +59,7 @@ public class Member extends BaseEntity {
     private List<MemberSkill> memberSkills = new ArrayList<>();
 
     @Builder
-    public Member(String email, String password, String provider, String nickname, Role roles, String introduction, String profileImageUrl) {
+    public Member(String email, String password, String provider, String nickname, Role roles, String introduction, String profileImageUrl, Occupation occupation) {
         this.email = email;
         this.password = password;
         this.provider = provider;
@@ -66,6 +67,7 @@ public class Member extends BaseEntity {
         this.roles = roles;
         this.introduction = introduction;
         this.profileImageUrl = profileImageUrl;
+        this.occupation = occupation;
     }
 
     public void changePassword(String encodePassword) {

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
@@ -42,11 +42,16 @@ public class Member extends BaseEntity {
     @NotNull
     private Role roles;
 
-    @Column(name = "introduction", nullable = true)
+    @Column(name = "introduction")
     private String introduction;
 
-    @Column(name = "profile_image_url", nullable = true)
+    @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "occupation_id")
+    @NotNull
+    private Occupation occupation;
 
     @Getter
     @OneToMany(mappedBy = "member")

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Member.java
@@ -74,8 +74,11 @@ public class Member extends BaseEntity {
         this.password = encodePassword;
     }
 
-    public void updateProfile(String profileImageUrl, String introduction) {
-        this.profileImageUrl = profileImageUrl;
+    public void setIntroduction(String introduction) {
         this.introduction = introduction;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Occupation.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Occupation.java
@@ -1,0 +1,30 @@
+package org.devridge.api.domain.member.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.devridge.common.dto.BaseEntity;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "occupation")
+@SQLDelete(sql = "UPDATE occupation SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
+public class Occupation extends BaseEntity {
+
+    @Getter
+    @NotNull
+    private String occupation;
+
+    public Occupation(String occupation) {
+        this.occupation = occupation;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/Occupation.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/Occupation.java
@@ -23,8 +23,4 @@ public class Occupation extends BaseEntity {
     @Getter
     @NotNull
     private String occupation;
-
-    public Occupation(String occupation) {
-        this.occupation = occupation;
-    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/entity/RefreshToken.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/entity/RefreshToken.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.devridge.api.domain.member.AbstractTimeEntity;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,6 +19,7 @@ public class RefreshToken extends AbstractTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private String refreshToken;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/api-module/src/main/java/org/devridge/api/domain/member/repository/MemberRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/repository/MemberRepository.java
@@ -2,11 +2,9 @@ package org.devridge.api.domain.member.repository;
 
 import org.devridge.api.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     public Optional<Member> findByEmail(String email);

--- a/api-module/src/main/java/org/devridge/api/domain/member/repository/OccupationRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/repository/OccupationRepository.java
@@ -1,0 +1,7 @@
+package org.devridge.api.domain.member.repository;
+
+import org.devridge.api.domain.member.entity.Occupation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OccupationRepository extends JpaRepository<Occupation, Long> {
+}

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -123,8 +123,6 @@ public class MemberService {
 
     @Transactional
     public void resetPassword(ResetPasswordRequest passwordRequest) {
-        Member member = getAuthenticatedMember();
-
         EmailVerification emailVerification = emailVerificationRepository.findTopByReceiptEmailOrderByCreatedAtDesc(
                 passwordRequest.getEmail()
         ).orElseThrow(() -> new EmailVerificationInvalidException());
@@ -134,6 +132,10 @@ public class MemberService {
         if (emailVerification.getExpireAt().isBefore(current) || !emailVerification.isCheckStatus()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
+
+        Member member = memberRepository.findByEmailAndProvider(passwordRequest.getEmail(), "normal").orElseThrow(
+                () -> new MemberNotFoundException()
+        );
 
         String encodedPassword = passwordEncoder.encode(passwordRequest.getPassword());
         member.changePassword(encodedPassword);

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -190,11 +190,13 @@ public class MemberService {
         List<Long> skillsToAdd = newSkillIds.stream()
                 .filter(skillId -> !currentSkillIds.contains(skillId))
                 .collect(Collectors.toList());
+
         addMemberSkills(member, skillsToAdd);
 
         List<Long> skillsToRemove = currentSkillIds.stream()
                 .filter(skillId -> !newSkillIds.contains(skillId))
                 .collect(Collectors.toList());
+
         removeMemberSkills(member.getId(), skillsToRemove);
 
         return newSkillIds;
@@ -209,9 +211,13 @@ public class MemberService {
     private void addMemberSkills(Member member, List<Long> skillIdsToAdd) {
         if (!skillIdsToAdd.isEmpty()) {
             List<Skill> skillsToAdd = skillRepository.findAllById(skillIdsToAdd);
+
             List<MemberSkill> newMemberSkills = skillsToAdd.stream()
-                    .map(skill -> new MemberSkill(new MemberSkillId(member.getId(), skill.getId()), member, skill))
+                    .map(skill -> new MemberSkill(
+                            new MemberSkillId(member.getId(), skill.getId()), member, skill)
+                    )
                     .collect(Collectors.toList());
+
             memberSkillRepository.saveAll(newMemberSkills);
         }
     }
@@ -234,7 +240,7 @@ public class MemberService {
 
     private Member getAuthenticatedMember() {
         Long memberId = SecurityContextHolderUtil.getMemberId();
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException());
+
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException());
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -165,14 +165,14 @@ public class MemberService {
                 updateMemberRequest.getProfileImageUrl(),
                 updateMemberRequest.getIntroduction()
         );
-        updateMemberSkills(member, updateMemberRequest);
+        List<Long> newSkillIds = updateMemberSkills(member, updateMemberRequest);
 
-        MemberResponse memberResponse = buildMemberResponse(member);
+        MemberResponse memberResponse = buildMemberResponse(member, newSkillIds);
 
         return new UpdateMemberResponse(memberResponse);
     }
 
-    private void updateMemberSkills(Member member, UpdateMemberProfileRequest updateMemberRequest) {
+    public List<Long> updateMemberSkills(Member member, UpdateMemberProfileRequest updateMemberRequest) {
         List<Long> currentSkillIds = getSkillIdListFromMember(member);
         List<Long> newSkillIds = updateMemberRequest.getSkillIds();
 
@@ -185,6 +185,8 @@ public class MemberService {
                 .filter(skillId -> !newSkillIds.contains(skillId))
                 .collect(Collectors.toList());
         removeMemberSkills(member.getId(), skillsToRemove);
+
+        return newSkillIds;
     }
 
     private List<Long> getSkillIdListFromMember(Member member) {
@@ -209,13 +211,13 @@ public class MemberService {
         }
     }
 
-    private MemberResponse buildMemberResponse(Member member) {
+    private MemberResponse buildMemberResponse(Member member, List<Long> SkillIds) {
         return MemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
                 .imageUrl(member.getProfileImageUrl())
                 .introduction(member.getIntroduction())
-                .skillIds(getSkillIdListFromMember(member))
+                .skillIds(SkillIds)
                 .build();
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -89,7 +89,7 @@ public class MemberService {
                 })
                 .collect(Collectors.toList());
 
-        memberSkillRepository.saveAll(memberSkills);
+        memberSkillRepository.bulkInsert(memberSkills);
     }
 
     @Transactional
@@ -216,7 +216,7 @@ public class MemberService {
                     )
                     .collect(Collectors.toList());
 
-            memberSkillRepository.saveAll(newMemberSkills);
+            memberSkillRepository.bulkInsert(newMemberSkills);
         }
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -24,7 +24,6 @@ import org.devridge.api.exception.member.*;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.devridge.common.exception.DataNotFoundException;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -167,12 +166,8 @@ public class MemberService {
     }
 
     @Transactional
-    public UpdateMemberResponse updateMember(Long targetMemberId, UpdateMemberProfileRequest updateMemberRequest) {
+    public UpdateMemberResponse updateMember(UpdateMemberProfileRequest updateMemberRequest) {
         Long currentMemberId = SecurityContextHolderUtil.getMemberId();
-
-        if (!targetMemberId.equals(currentMemberId)) {
-            throw new AccessDeniedException("거부된 접근입니다.");
-        }
 
         Member member = memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new MemberNotFoundException());

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -135,10 +135,8 @@ public class MemberService {
     public void updateMember(UpdateMemberProfileRequest updateMemberRequest) {
         Member member = getAuthenticatedMember();
 
-        member.updateProfile(
-                updateMemberRequest.getProfileImageUrl(),
-                updateMemberRequest.getIntroduction()
-        );
+        member.setProfileImageUrl(updateMemberRequest.getProfileImageUrl());
+        member.setIntroduction(updateMemberRequest.getIntroduction());
 
         updateMemberSkills(member, updateMemberRequest);
     }
@@ -155,7 +153,7 @@ public class MemberService {
 
     // TODO: DB 조회 -> 캐싱
     public List<Skill> areSkillsValid(List<Long> skillIds) {
-        List<Skill> skills = skillRepository.findAllById(skillIds);
+        List<Skill> skills = skillRepository.findSkillsByIds(skillIds);
 
         if (skills.size() != skillIds.size()) {
             throw new SkillsNotValidException();
@@ -210,7 +208,7 @@ public class MemberService {
 
     private void addMemberSkills(Member member, List<Long> skillIdsToAdd) {
         if (!skillIdsToAdd.isEmpty()) {
-            List<Skill> skillsToAdd = skillRepository.findAllById(skillIdsToAdd);
+            List<Skill> skillsToAdd = skillRepository.findSkillsByIds(skillIdsToAdd);
 
             List<MemberSkill> newMemberSkills = skillsToAdd.stream()
                     .map(skill -> new MemberSkill(

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/OccupationService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/OccupationService.java
@@ -1,12 +1,24 @@
 package org.devridge.api.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.member.dto.response.OccupationInformation;
 import org.devridge.api.domain.member.repository.OccupationRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class OccupationService {
 
     private final OccupationRepository occupationRepository;
+
+    public List<OccupationInformation> getAllOccupations() {
+        return occupationRepository.findAll()
+                .stream()
+                .map(occupation -> new OccupationInformation(
+                        occupation.getId(), occupation.getOccupation())
+                ).collect(Collectors.toList());
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/OccupationService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/OccupationService.java
@@ -1,0 +1,12 @@
+package org.devridge.api.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.member.repository.OccupationRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OccupationService {
+
+    private final OccupationRepository occupationRepository;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/entity/MemberSkill.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/entity/MemberSkill.java
@@ -8,8 +8,6 @@ import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.skill.entity.key.MemberSkillId;
 import org.devridge.common.dto.BaseTimeEntity;
 import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -17,8 +15,6 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
-@SQLDelete(sql = "UPDATE member_skill SET is_deleted = true WHERE id = ?")
-@Where(clause = "is_deleted = false")
 @Table(name = "member_skill")
 public class MemberSkill extends BaseTimeEntity {
 

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepository.java
@@ -3,6 +3,7 @@ package org.devridge.api.domain.skill.repository;
 import org.devridge.api.domain.skill.entity.MemberSkill;
 import org.devridge.api.domain.skill.entity.key.MemberSkillId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,4 +14,10 @@ public interface MemberSkillRepository extends JpaRepository<MemberSkill, Member
     @Query("select memberSkill.id.skillId FROM MemberSkill memberSkill " +
             "WHERE memberSkill.id.memberId = :memberId")
     List<Long> findSkillIdByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("DELETE FROM MemberSkill ms " +
+            "WHERE ms.id.memberId = :memberId AND ms.id.skillId " +
+            "IN :skillsToRemove")
+    void deleteAllByMemberIdAndSkillIdIn(@Param("memberId") Long memberId, @Param("skillsToRemove") List<Long> skillsToRemove);
 }

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MemberSkillRepository extends JpaRepository<MemberSkill, MemberSkillId> {
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, MemberSkillId>, MemberSkillRepositoryCustom {
 
     @Query("select memberSkill.id.skillId FROM MemberSkill memberSkill " +
             "WHERE memberSkill.id.memberId = :memberId")

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepositoryCustom.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.devridge.api.domain.skill.repository;
+
+import org.devridge.api.domain.skill.entity.MemberSkill;
+
+import java.util.List;
+
+public interface MemberSkillRepositoryCustom {
+
+    void bulkInsert(List<MemberSkill> memberSkills);
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepositoryCustomImpl.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/MemberSkillRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package org.devridge.api.domain.skill.repository;
+
+import org.devridge.api.domain.skill.entity.MemberSkill;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemberSkillRepositoryCustomImpl implements MemberSkillRepositoryCustom {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public MemberSkillRepositoryCustomImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    @Transactional
+    public void bulkInsert(List<MemberSkill> memberSkills) {
+        String sql = "INSERT INTO member_skill (member_id, skill_id) VALUES (?, ?)";
+        List<Object[]> batchArgs = new ArrayList<>();
+
+        for (MemberSkill memberSkill : memberSkills) {
+            Object[] values = {
+                    memberSkill.getId().getMemberId(),
+                    memberSkill.getId().getSkillId()
+            };
+            batchArgs.add(values);
+        }
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/SkillRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/SkillRepository.java
@@ -2,10 +2,13 @@ package org.devridge.api.domain.skill.repository;
 
 import org.devridge.api.domain.skill.entity.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface SkillRepository extends JpaRepository<Skill, Long> {
 
-    public Optional<Skill> findBySkill(String skill);
+    @Query("SELECT s FROM Skill s WHERE s.id IN :ids")
+    List<Skill> findSkillsByIds(@Param("ids") List<Long> ids);
 }

--- a/api-module/src/main/java/org/devridge/api/exception/GlobalExceptionHandler.java
+++ b/api-module/src/main/java/org/devridge/api/exception/GlobalExceptionHandler.java
@@ -1,13 +1,6 @@
 package org.devridge.api.exception;
 
-import java.util.NoSuchElementException;
-import javax.persistence.EntityNotFoundException;
-import org.devridge.api.exception.member.DuplEmailException;
-import org.devridge.api.exception.member.DuplNicknameException;
-import org.devridge.api.exception.member.MemberNotFoundException;
-import org.devridge.api.exception.member.PasswordNotMatchException;
-import org.devridge.api.exception.member.SkillsNotValidException;
-import org.devridge.api.exception.member.WeakPasswordException;
+import org.devridge.api.exception.member.*;
 import org.devridge.common.dto.BaseErrorResponse;
 import org.devridge.common.dto.BaseResponse;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -16,6 +9,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -75,7 +71,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<BaseErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
-        BaseErrorResponse response = new BaseErrorResponse("거부된 접근입니다.");
+        BaseErrorResponse response = new BaseErrorResponse(e.getMessage());
         return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/exception/member/MemberNotFoundException.java
+++ b/api-module/src/main/java/org/devridge/api/exception/member/MemberNotFoundException.java
@@ -7,10 +7,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Getter
 @ResponseStatus(HttpStatus.NOT_FOUND)
 public class MemberNotFoundException extends RuntimeException {
-    private String message;
 
-    public MemberNotFoundException(String message) {
-        super(message);
-        this.message = message;
+    public MemberNotFoundException() {
+        super();
     }
 }

--- a/api-module/src/main/java/org/devridge/api/security/config/SecurityConfig.java
+++ b/api-module/src/main/java/org/devridge/api/security/config/SecurityConfig.java
@@ -64,8 +64,10 @@ public class SecurityConfig {
             .authorizeRequests()
             .antMatchers(securityConstant().ALL_PERMIT_PATHS).permitAll()
             .antMatchers(HttpMethod.GET, "/api/qna/**").permitAll()
-            .antMatchers("/api/qna/**").authenticated()
+            .antMatchers(HttpMethod.GET, "/api/occupations").permitAll()
             .antMatchers(HttpMethod.GET, "/api/community/**").permitAll()
+
+            .antMatchers("/api/qna/**").authenticated()
             .antMatchers("/api/community/**").authenticated()
             .antMatchers(securityConstant().USER_ROLE_PERMIT_PATHS).hasRole(SecurityConstant.USER_ROLE)
             .anyRequest().denyAll();

--- a/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthenticationFilter.java
+++ b/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package org.devridge.api.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.devridge.api.domain.member.dto.response.LoginResponse;
-import org.devridge.api.domain.member.dto.response.MemberResponse;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.entity.RefreshToken;
 import org.devridge.api.domain.member.repository.RefreshTokenRepository;
@@ -68,17 +67,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         // 3. AccessToken 발급
         String accessToken = JwtUtil.createAccessToken(member, refreshTokenId);
 
-        List<Long> skillIdList = getSkillIdListFromMember(member);
-
-        MemberResponse memberResponse = MemberResponse.builder()
-                .id(member.getId())
-                .nickname(member.getNickname())
-                .imageUrl(member.getProfileImageUrl())
-                .introduction(member.getIntroduction())
-                .skillIds(skillIdList)
-                .build();
-
-        LoginResponse loginResponse = new LoginResponse(accessToken, memberResponse);
+        LoginResponse loginResponse = new LoginResponse(accessToken);
 
         ResponseUtil.createResponseBody(response, loginResponse, HttpStatus.OK);
     }

--- a/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthorizationFilter.java
+++ b/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthorizationFilter.java
@@ -49,8 +49,9 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     private final List<RequestMatcher> excludedUrlPatterns = Arrays.asList(//이 필터 적용 안할 url 지정
             new AntPathRequestMatcher("/api/email-verifications"),
-            new AntPathRequestMatcher("/api/users/reset-password")
-            // 추가적인 URL 패턴을 필요에 따라 설정
+            new AntPathRequestMatcher("/api/users", "POST"),
+            new AntPathRequestMatcher("/api/login", "POST"),
+            new AntPathRequestMatcher("/api/users/reset-password", "PATCH")
     );
 
     @Override

--- a/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthorizationFilter.java
+++ b/api-module/src/main/java/org/devridge/api/security/filter/JwtAuthorizationFilter.java
@@ -48,7 +48,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     // 3. DB 에서 리프레시토큰 조회. 리프레시 토큰이 유효하다면 -> 새로운 액세스토큰 발급, 그렇지 않다면 -> 인증된 객체를 저장하지 않고 doFilter
 
     private final List<RequestMatcher> excludedUrlPatterns = Arrays.asList(//이 필터 적용 안할 url 지정
-            new AntPathRequestMatcher("/api/email-verifications")
+            new AntPathRequestMatcher("/api/email-verifications"),
+            new AntPathRequestMatcher("/api/users/reset-password")
             // 추가적인 URL 패턴을 필요에 따라 설정
     );
 

--- a/api-module/src/main/java/org/devridge/api/util/SecurityContextHolderUtil.java
+++ b/api-module/src/main/java/org/devridge/api/util/SecurityContextHolderUtil.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityContextHolderUtil {
-
+    // TODO: 멀티쓰레드 환경에서 동기화 작업
     public static Long getMemberId() {
         CustomMemberDetails principal = getCustomMemberDetails();
         Long memberId = principal.getMember().getId();

--- a/api-module/src/main/java/org/devridge/api/util/SecurityContextHolderUtil.java
+++ b/api-module/src/main/java/org/devridge/api/util/SecurityContextHolderUtil.java
@@ -2,24 +2,39 @@ package org.devridge.api.util;
 
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.security.auth.CustomMemberDetails;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityContextHolderUtil {
 
     public static Long getMemberId() {
-        CustomMemberDetails principal = (CustomMemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        CustomMemberDetails principal = getCustomMemberDetails();
         Long memberId = principal.getMember().getId();
         return memberId;
     }
 
     public static String getEmail() {
-        CustomMemberDetails principal = (CustomMemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        CustomMemberDetails principal = getCustomMemberDetails();
         String email = principal.getUsername();
         return email;
     }
 
     public static Member getMember() {
-        CustomMemberDetails principal = (CustomMemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        CustomMemberDetails principal = getCustomMemberDetails();
         return principal.getMember();
+    }
+
+    private static CustomMemberDetails getCustomMemberDetails() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("authentication is not valid");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomMemberDetails)) {
+            throw new IllegalStateException("principal is not valid");
+        }
+
+        return (CustomMemberDetails) principal;
     }
 }


### PR DESCRIPTION
## Description ✍️
* 멤버 프로필 수정 기능을 구현합니다.
* 회원 가입 시 누락되었던 한줄소개(introduction), 직군(occupation)을 추가합니다.
* 멤버 도메인 관련 기능을 전체적으로 리팩토링, 보완하였습니다.

#### API 변경 사항
- 회원 가입
- 회원 프로필 수정
- 비밀번호 변경
- 유저 디테일 API

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?