### PR TITLE
이미지를 S3에 저장하기 위한 이미지 API를 구현합니다.

### DIFF
--- a/api-module/build.gradle
+++ b/api-module/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    implementation 'com.amazonaws:aws-java-sdk:1.12.174'
 }
 
 tasks.named('test') {

--- a/api-module/src/main/java/org/devridge/api/config/S3Config.java
+++ b/api-module/src/main/java/org/devridge/api/config/S3Config.java
@@ -1,0 +1,31 @@
+package org.devridge.api.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${devridge.s3.accessKey}")
+    private String accessKey;
+
+    @Value("${devridge.s3.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        return AmazonS3ClientBuilder.standard()
+            .withCredentials(
+                new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
+            )
+            .withRegion(Regions.AP_NORTHEAST_2)
+            .build();
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
@@ -1,0 +1,29 @@
+package org.devridge.api.domain.s3.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
+import org.devridge.api.domain.s3.service.S3Service;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/images")
+    public ResponseEntity<UploadImageResponse> uploadImage(@RequestPart MultipartFile image) throws IOException {
+        UploadImageResponse response = s3Service.uploadImage(image);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
@@ -6,10 +6,7 @@ import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
 import org.devridge.api.domain.s3.service.S3Service;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;

--- a/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
 import org.devridge.api.domain.s3.service.S3Service;
 
+import org.devridge.api.domain.s3.validator.ValidateImagePath;
+import org.devridge.api.domain.s3.validator.type.ImagePath;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,8 +21,11 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping("/images")
-    public ResponseEntity<UploadImageResponse> uploadImage(@RequestPart MultipartFile image) throws IOException {
-        UploadImageResponse response = s3Service.uploadImage(image);
+    public ResponseEntity<UploadImageResponse> uploadImage(
+        @RequestPart(value = "image") MultipartFile image,
+        @RequestPart(value = "path") @ValidateImagePath(enumClass = ImagePath.class) String path
+    ) throws IOException {
+        UploadImageResponse response = s3Service.uploadImage(image, path);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/controller/S3Controller.java
@@ -2,6 +2,7 @@ package org.devridge.api.domain.s3.controller;
 
 import lombok.RequiredArgsConstructor;
 
+import org.devridge.api.domain.s3.dto.request.DeleteImageRequest;
 import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
 import org.devridge.api.domain.s3.service.S3Service;
 
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.io.IOException;
 
 @RestController
@@ -27,5 +29,11 @@ public class S3Controller {
     ) throws IOException {
         UploadImageResponse response = s3Service.uploadImage(image, path);
         return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/images")
+    public ResponseEntity<Void> deleteImage(@RequestBody @Valid DeleteImageRequest imageRequest) {
+        s3Service.deleteImage(imageRequest.getName());
+        return ResponseEntity.ok().build();
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/s3/dto/request/DeleteImageRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/dto/request/DeleteImageRequest.java
@@ -1,0 +1,9 @@
+package org.devridge.api.domain.s3.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteImageRequest {
+
+    private String name;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/dto/response/UploadImageResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/dto/response/UploadImageResponse.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 @Getter
 public class UploadImageResponse {
 
-    private String imageUrl;
+    private String imagePath;
 
-    public UploadImageResponse(String imageUrl) {
-        this.imageUrl = imageUrl;
+    public UploadImageResponse(String imagePath) {
+        this.imagePath = imagePath;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/s3/dto/response/UploadImageResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/dto/response/UploadImageResponse.java
@@ -1,0 +1,13 @@
+package org.devridge.api.domain.s3.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UploadImageResponse {
+
+    private String imageUrl;
+
+    public UploadImageResponse(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
@@ -24,9 +24,6 @@ public class S3Service {
     @Value("${devridge.s3.bucketName}")
     private String bucketName;
 
-    @Value("${devridge.s3.urlPrefix}")
-    private String urlPrefix;
-
     public UploadImageResponse uploadImage(MultipartFile image) throws IOException {
         String fileName = this.getFileName(image);
         ObjectMetadata objectMetadata = this.getObjectMetadata(image);
@@ -37,7 +34,7 @@ public class S3Service {
 
         s3Client.putObject(request);
 
-        return new UploadImageResponse(urlPrefix + "/" + fileName);
+        return new UploadImageResponse(s3Client.getUrl(bucketName, fileName).toString());
     }
 
     private String getFileName(MultipartFile image) {

--- a/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
@@ -35,7 +35,7 @@ public class S3Service {
 
         s3Client.putObject(request);
 
-        return new UploadImageResponse(s3Client.getUrl(bucketName, fileName).toString());
+        return new UploadImageResponse(fileName);
     }
 
     public void deleteImage(String name) {

--- a/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
@@ -24,8 +24,8 @@ public class S3Service {
     @Value("${devridge.s3.bucketName}")
     private String bucketName;
 
-    public UploadImageResponse uploadImage(MultipartFile image) throws IOException {
-        String fileName = this.getFileName(image);
+    public UploadImageResponse uploadImage(MultipartFile image, String path) throws IOException {
+        String fileName = this.getFileName(image, path);
         ObjectMetadata objectMetadata = this.getObjectMetadata(image);
 
         PutObjectRequest request = new PutObjectRequest(
@@ -37,11 +37,11 @@ public class S3Service {
         return new UploadImageResponse(s3Client.getUrl(bucketName, fileName).toString());
     }
 
-    private String getFileName(MultipartFile image) {
+    private String getFileName(MultipartFile image, String imagePath) {
         String originalFileName = image.getOriginalFilename();
         String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
 
-        return UUID.randomUUID() + extension;
+        return imagePath + "/" + UUID.randomUUID() + extension;
     }
 
     private ObjectMetadata getObjectMetadata(MultipartFile image) {

--- a/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
@@ -1,0 +1,58 @@
+package org.devridge.api.domain.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+
+import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${devridge.s3.bucketName}")
+    private String bucketName;
+
+    @Value("${devridge.s3.urlPrefix}")
+    private String urlPrefix;
+
+    public UploadImageResponse uploadImage(MultipartFile image) throws IOException {
+        String fileName = this.getFileName(image);
+        ObjectMetadata objectMetadata = this.getObjectMetadata(image);
+
+        PutObjectRequest request = new PutObjectRequest(
+            bucketName, fileName, image.getInputStream(), objectMetadata
+        );
+
+        s3Client.putObject(request);
+
+        return new UploadImageResponse(urlPrefix + "/" + fileName);
+    }
+
+    private String getFileName(MultipartFile image) {
+        String originalFileName = image.getOriginalFilename();
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+
+        return UUID.randomUUID() + extension;
+    }
+
+    private ObjectMetadata getObjectMetadata(MultipartFile image) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+
+        objectMetadata.setContentLength(image.getSize());
+        objectMetadata.setContentType(image.getContentType());
+
+        return objectMetadata;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/service/S3Service.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 
 import org.devridge.api.domain.s3.dto.response.UploadImageResponse;
+import org.devridge.common.exception.DataNotFoundException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,6 +36,16 @@ public class S3Service {
         s3Client.putObject(request);
 
         return new UploadImageResponse(s3Client.getUrl(bucketName, fileName).toString());
+    }
+
+    public void deleteImage(String name) {
+        boolean isExist = s3Client.doesObjectExist(bucketName, name);
+
+        if (isExist) {
+            s3Client.deleteObject(bucketName, name);
+        } else {
+            throw new DataNotFoundException();
+        }
     }
 
     private String getFileName(MultipartFile image, String imagePath) {

--- a/api-module/src/main/java/org/devridge/api/domain/s3/validator/PathValidator.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/validator/PathValidator.java
@@ -1,0 +1,32 @@
+package org.devridge.api.domain.s3.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PathValidator implements ConstraintValidator<ValidateImagePath, String> {
+
+    private ValidateImagePath validateImagePath;
+
+    @Override
+    public void initialize(ValidateImagePath constraintAnnotation) {
+        this.validateImagePath = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        Enum<?>[] enumValues = this.validateImagePath.enumClass().getEnumConstants();
+
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (
+                    value.equals(enumValue.toString())
+                    || this.validateImagePath.ignoreCase() && value.equalsIgnoreCase(enumValue.toString())
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/validator/ValidateImagePath.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/validator/ValidateImagePath.java
@@ -1,0 +1,23 @@
+package org.devridge.api.domain.s3.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+
+@Documented
+@Target({ PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { PathValidator.class })
+public @interface ValidateImagePath {
+
+    Class<? extends Enum<?>> enumClass();
+    String message() default "올바른 s3 경로가 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    boolean ignoreCase() default true;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/s3/validator/type/ImagePath.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/validator/type/ImagePath.java
@@ -1,0 +1,5 @@
+package org.devridge.api.domain.s3.validator.type;
+
+public enum ImagePath {
+    qna
+}

--- a/api-module/src/main/java/org/devridge/api/exception/FileExceptionHandler.java
+++ b/api-module/src/main/java/org/devridge/api/exception/FileExceptionHandler.java
@@ -1,0 +1,16 @@
+package org.devridge.api.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.IOException;
+
+@RestControllerAdvice
+public class FileExceptionHandler {
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<Void> handleIoException() {
+        return ResponseEntity.internalServerError().build();
+    }
+}


### PR DESCRIPTION
## Description ✍️
* S3에 이미지 저장 및 삭제하기 위한 API를 구현합니다.
* 추후 이미지 저장이 필요한 경우 해당 코드를 참고하셔서 DB에 경로만 저장해주시면 됩니다.

## 테스트 시 유의사항 ⚠️
* 아래 링크에서 이미지 저장, 이미지 삭제 부분을 참고하셔서 테스트해주시면 됩니다.
* https://documenter.getpostman.com/view/19463591/2s9YsRaTbu
* Merge 후 API 명세서에 업데이트 하겠습니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [x] 모든 리뷰어의 승인을 받았나요?