### PR TITLE
비밀번호 재설정 기능을 수정 및 보완합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/domain/emailverification/controller/EmailVerificationController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/emailverification/controller/EmailVerificationController.java
@@ -2,6 +2,7 @@ package org.devridge.api.domain.emailverification.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.emailverification.dto.request.SendEmailRequest;
+import org.devridge.api.domain.emailverification.dto.response.EmailVerificationResponse;
 import org.devridge.api.domain.emailverification.service.EmailVerificationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,12 +24,14 @@ public class EmailVerificationController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping
-    public ResponseEntity<Void> checkVerificationCode(
+    @PostMapping("/code")
+    public ResponseEntity<EmailVerificationResponse> checkVerificationCode(
             @RequestParam("email") String email,
             @RequestParam("code") String code
     ) {
-        emailVerificationService.checkVerificationCode(email, code);
-        return ResponseEntity.ok().build();
+        String temporaryJwt = emailVerificationService.checkVerificationCode(email, code);
+        EmailVerificationResponse emailResponse = new EmailVerificationResponse(temporaryJwt);
+
+        return ResponseEntity.ok().body(emailResponse);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/emailverification/dto/response/EmailVerificationResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/emailverification/dto/response/EmailVerificationResponse.java
@@ -1,0 +1,12 @@
+package org.devridge.api.domain.emailverification.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class EmailVerificationResponse {
+    String token;
+
+    public EmailVerificationResponse(String token) {
+        this.token = token;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/emailverification/service/EmailVerificationService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/emailverification/service/EmailVerificationService.java
@@ -5,6 +5,7 @@ import org.devridge.api.domain.emailverification.dto.request.SendEmailRequest;
 import org.devridge.api.domain.emailverification.entity.EmailVerification;
 import org.devridge.api.domain.emailverification.repository.EmailVerificationRepository;
 import org.devridge.api.domain.emailverification.exception.EmailVerificationInvalidException;
+import org.devridge.api.util.JwtUtil;
 import org.devridge.api.util.RandomGeneratorUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -58,7 +59,7 @@ public class EmailVerificationService {
     }
 
     @Transactional
-    public void checkVerificationCode(String email, String code) {
+    public String checkVerificationCode(String email, String code) {
         EmailVerification emailVerification = emailVerificationRepository.findTopByReceiptEmailOrderByCreatedAtDesc(email)
                 .orElseThrow(() -> new EmailVerificationInvalidException(404, "해당 데이터를 찾을 수 없습니다."));
 
@@ -68,6 +69,8 @@ public class EmailVerificationService {
         validateVerificationCode(code, emailVerification.getContent());
 
         emailVerification.changeCheckStatus();
+
+        return JwtUtil.createTemporaryJwt(email);
     }
 
     private static void validateEmailVerification(EmailVerification emailVerification, LocalDateTime current) {

--- a/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/dto/request/ResetPasswordRequest.java
@@ -14,8 +14,11 @@ public class ResetPasswordRequest {
     @Email(message = "유효하지 않은 이메일 형식입니다.")
     private String email;
 
-    @NotBlank(message = "빈 패스워드를 입력할 수 없습니다.")
-    @Size(min = 8, max = 20, message = "패스워드는 8자 이상 20자 이하이어야 합니다.")
+    @NotBlank(message = "재설정하려는 비밀번호를 입력하세요.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", message = "패스워드는 영문자 + 숫자 조합이어야 합니다.")
     private String password;
+
+    @NotBlank(message = "임시 토큰을 입력하세요.")
+    private String tempJwt;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/member/service/MemberService.java
@@ -83,7 +83,7 @@ public class MemberService {
 
     @Transactional
     public void resetPassword(ResetPasswordRequest passwordRequest) {
-        checkTempJwt(passwordRequest.getTempJwt());
+        checkTemporaryTokenForPasswordReset(passwordRequest.getTempJwt());
 
         EmailVerification emailVerification = checkEmailVerification(passwordRequest);
 
@@ -261,9 +261,14 @@ public class MemberService {
                 .build();
     }
 
-    private Claims checkTempJwt(String temporaryToken) {
+    private Claims checkTemporaryTokenForPasswordReset(String temporaryToken) {
         try {
-            return AccessTokenUtil.getClaimsFromAccessToken(temporaryToken);
+            Claims claims = AccessTokenUtil.getClaimsFromAccessToken(temporaryToken);
+
+            if (!claims.get("purpose").equals("password-reset")) {
+                throw new AccessTokenInvalidException(403, "토큰이 올바르지 않습니다.");
+            }
+            return claims;
         } catch (Exception e) {
             throw new AccessTokenInvalidException(403, "토큰이 올바르지 않습니다.");
         }

--- a/api-module/src/main/java/org/devridge/api/domain/sociallogin/service/SocialLoginService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/sociallogin/service/SocialLoginService.java
@@ -85,7 +85,7 @@ public class SocialLoginService {
     public TokenResponse signUpAndLogin(SocialLoginSignUp socialLoginRequest) {
         checkDuplNickname(socialLoginRequest.getNickname());
 
-        Claims claims = checkTempJwt(socialLoginRequest);
+        Claims claims = checkTemporaryTokenForSocialLogin(socialLoginRequest.getTempJwt());
 
         String memberEmail = (String) claims.get("memberEmail");
         String provider = (String) claims.get("provider");
@@ -104,11 +104,14 @@ public class SocialLoginService {
         }
     }
 
-    private static Claims checkTempJwt(SocialLoginSignUp socialLoginRequest) {
-        String tempJwt = socialLoginRequest.getTempJwt();
-
+    private static Claims checkTemporaryTokenForSocialLogin(String temporaryToken) {
         try {
-            return AccessTokenUtil.getClaimsFromAccessToken(tempJwt);
+            Claims claims = AccessTokenUtil.getClaimsFromAccessToken(temporaryToken);
+
+            if (!claims.get("purpose").equals("social-login")) {
+                throw new AccessTokenInvalidException(403, "잘못된 토큰입니다.");
+            }
+            return claims;
         } catch (Exception e) {
             throw new AccessTokenInvalidException(401, "로그아웃 되었습니다. 다시 로그인해주세요.");
         }

--- a/api-module/src/main/java/org/devridge/api/security/config/SecurityConfig.java
+++ b/api-module/src/main/java/org/devridge/api/security/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
             .antMatchers(HttpMethod.GET, "/api/qna/**").permitAll()
             .antMatchers(HttpMethod.GET, "/api/occupations").permitAll()
             .antMatchers(HttpMethod.GET, "/api/community/**").permitAll()
+            .antMatchers(HttpMethod.PATCH, "/api/users/reset-password").permitAll()
 
             .antMatchers("/api/qna/**").authenticated()
             .antMatchers("/api/community/**").authenticated()

--- a/api-module/src/main/java/org/devridge/api/util/JwtUtil.java
+++ b/api-module/src/main/java/org/devridge/api/util/JwtUtil.java
@@ -46,6 +46,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .setSubject("temporaryJwt")
                 .claim("memberEmail", oAuth2MemberInfo.getEmail())
+                .claim("purpose", "social-login")
                 .claim("provider", oAuth2MemberInfo.getProvider())
                 .setExpiration(createTokenExpiration(TOKEN_VALIDITY_TIME_IN_HOURS))
                 .signWith(createSigningKey(AuthProperties.getAccessSecret()), SignatureAlgorithm.HS256)

--- a/api-module/src/main/java/org/devridge/api/util/JwtUtil.java
+++ b/api-module/src/main/java/org/devridge/api/util/JwtUtil.java
@@ -52,6 +52,16 @@ public class JwtUtil {
                 .compact();
     }
 
+    public static String createTemporaryJwt(String email) {
+        return Jwts.builder()
+                .setSubject("temporaryJwt")
+                .claim("memberEmail", email)
+                .claim("purpose", "password-reset")
+                .setExpiration(createTokenExpiration(TOKEN_VALIDITY_TIME_IN_HOURS))
+                .signWith(createSigningKey(AuthProperties.getAccessSecret()), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     public static ResponseCookie generateRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("devridge", refreshToken)
                 .httpOnly(true)


### PR DESCRIPTION
## Description ✍️
* 비밀번호 재설정 시 발생하는 오류를 수정했습니다.
* 이메일 인증 완료 시, 임시 토큰을 발급하는 로직을 추가하여 비밀번호를 재설정 시 사용하도록 변경했습니다.
* 비밀번호 재설정 시 발생 가능한 보안 상 취약한 부분을 상당 부분 보완하였습니다.

## Screen Shot 📷
<img width="800" alt="스크린샷 2024-02-19 오후 2 32 13" src="https://github.com/devridge-team-project/devridge-server/assets/56336436/d71a5ba3-2b41-467c-871d-df68367f0cb1">

이메일 인증에 성공하면 임시 토큰을 발급합니다.
해당 임시 토큰은 비밀번호 재설정 시에 필요합니다.

## 테스트 시 유의사항 ⚠️
* 이메일 인증 시 임시 토큰이 발급되는지 확인해주세요.
* 비밀번호 재설정 API에 임시 토큰을 넣고 테스트 해주시면 감사하겠습니다.

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
