### PR TITLE
Nginx에서 발생하는 CORS 문제 및 https 문제를 해결합니다.

### DIFF
--- a/nginx/nginx.blue.conf
+++ b/nginx/nginx.blue.conf
@@ -3,17 +3,23 @@ events {
 }
 
 http {
+    map $http_origin $allowed_origin {
+        default "";
+        "http://localhost:3000" $http_origin;
+        "https://devridge-client.vercel.app" $http_origin;
+    }
+
     upstream backend {
         server localhost:8080;
     }
 
     server {
 
-        server_name {dns_name};
+        server_name devridge6.duckdns.org;
 
         location /api {
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+                add_header 'Access-Control-Allow-Origin' $allowed_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
                 add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
                 add_header 'Access-Control-Allow-Credentials' 'true';
@@ -21,7 +27,7 @@ http {
             }
 
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+            add_header 'Access-Control-Allow-Origin' $allowed_origin always;
             add_header 'Access-Control-Allow-Credentials' 'true';
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -30,7 +36,22 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
-
         }
+
+        listen 443 ssl; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/devridge6.duckdns.org/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/devridge6.duckdns.org/privkey.pem; # managed by Certbot
+        include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+    }
+
+    server {
+        if ($host = devridge6.duckdns.org) {
+                 return 301 https://$host$request_uri;
+        } # managed by Certbot
+
+        server_name devridge6.duckdns.org;
+        listen 80;
+        return 404; # managed by Certbot
     }
 }

--- a/nginx/nginx.blue.conf
+++ b/nginx/nginx.blue.conf
@@ -11,8 +11,17 @@ http {
         listen 80;
 
         location /api {
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                return 204;
+            }
+
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/nginx/nginx.blue.conf
+++ b/nginx/nginx.blue.conf
@@ -8,7 +8,8 @@ http {
     }
 
     server {
-        listen 80;
+
+        server_name {dns_name};
 
         location /api {
             if ($request_method = 'OPTIONS') {
@@ -20,8 +21,8 @@ http {
             }
 
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+            add_header 'Access-Control-Allow-Credentials' 'true';
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -29,6 +30,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
+
         }
     }
 }

--- a/nginx/nginx.green.conf
+++ b/nginx/nginx.green.conf
@@ -11,8 +11,17 @@ http {
         listen 80;
 
         location /api {
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                return 204;
+            }
+
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/nginx/nginx.green.conf
+++ b/nginx/nginx.green.conf
@@ -3,16 +3,23 @@ events {
 }
 
 http {
+    map $http_origin $allowed_origin {
+        default "";
+        "http://localhost:3000" $http_origin;
+        "https://devridge-client.vercel.app" $http_origin;
+    }
+
     upstream backend {
         server localhost:8081;
     }
 
     server {
-        server_name {dns_name};
+
+        server_name devridge6.duckdns.org;
 
         location /api {
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';
+                add_header 'Access-Control-Allow-Origin' $allowed_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
                 add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
                 add_header 'Access-Control-Allow-Credentials' 'true';
@@ -20,7 +27,7 @@ http {
             }
 
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+            add_header 'Access-Control-Allow-Origin' $allowed_origin always;
             add_header 'Access-Control-Allow-Credentials' 'true';
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -30,5 +37,21 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
         }
+
+        listen 443 ssl; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/devridge6.duckdns.org/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/devridge6.duckdns.org/privkey.pem; # managed by Certbot
+        include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+    }
+
+    server {
+        if ($host = devridge6.duckdns.org) {
+             return 301 https://$host$request_uri;
+        } # managed by Certbot
+
+        server_name devridge6.duckdns.org;
+        listen 80;
+        return 404; # managed by Certbot
     }
 }

--- a/nginx/nginx.green.conf
+++ b/nginx/nginx.green.conf
@@ -8,7 +8,7 @@ http {
     }
 
     server {
-        listen 80;
+        server_name {dns_name};
 
         location /api {
             if ($request_method = 'OPTIONS') {
@@ -20,8 +20,8 @@ http {
             }
 
             proxy_pass http://backend/api;
-            add_header 'Access-Control-Allow-Credentials' 'true';
             add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+            add_header 'Access-Control-Allow-Credentials' 'true';
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## Description ✍️
* Preflight 요청 시 응답 해더에서 발생하는 문제를 add_header 'Access-Control-Allow-Origin' 'http://localhost:3000';로 해결했습니다.
* The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. 문제가 발생하여 와일드 카드를 제거했습니다.
* 추가적으로 https가 nginx 설정 파일에 따라 인증이 안되는 부분이 있어 이 부분도 같이 수정했습니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?