### PR TITLE
커뮤니티 이슈 게시글에 이미지 첨부, 삭제 기능을 추가하고 커뮤니티의 프로젝트 게시글 api를 추가합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -1,9 +1,11 @@
 package org.devridge.api.domain.community.controller;
 
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
+import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.service.ProjectService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,13 +37,13 @@ public class ProjectController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getAllProject() {
-
-        return ResponseEntity.ok().body(projectService.getAllProject());
+    public ResponseEntity<List<ProjectListResponse>> getAllProject() {
+        List<ProjectListResponse> projectListResponses = projectService.getAllProject();
+        return ResponseEntity.ok().body(projectListResponses);
     }
 
     @PutMapping("/{projectId}")
-    public ResponseEntity<?> updateProject(
+    public ResponseEntity<Void> updateProject(
         @PathVariable Long projectId,
         @RequestBody ProjectRequest request
     ) {
@@ -50,8 +52,7 @@ public class ProjectController {
     }
 
     @DeleteMapping("/{projectId}")
-    public ResponseEntity<?> deleteProject(@PathVariable Long projectId) {
-
+    public ResponseEntity<Void> deleteProject(@PathVariable Long projectId) {
         projectService.deleteProject(projectId);
         return ResponseEntity.ok().build();
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/project")
+@RequestMapping("/api/community/projects")
 @RequiredArgsConstructor
 public class ProjectController {
 
@@ -27,7 +27,7 @@ public class ProjectController {
     @PostMapping
     public ResponseEntity<Void> createProject(@RequestBody ProjectRequest request) {
         Long projectId = projectService.createProject(request);
-        return ResponseEntity.created(URI.create("/api/project/" + projectId)).build();
+        return ResponseEntity.created(URI.create("/api/community/projects/" + projectId)).build();
     }
 
     @GetMapping("/{projectId}")

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -3,6 +3,7 @@ package org.devridge.api.domain.community.controller;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
 import org.devridge.api.domain.community.service.ProjectService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +26,12 @@ public class ProjectController {
     public ResponseEntity<Void> createProject(@RequestBody ProjectRequest request) {
         Long projectId = projectService.createProject(request);
         return ResponseEntity.created(URI.create("/api/project/" + projectId)).build();
+    }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectDetailResponse> getProjectDetail(@PathVariable Long projectId) {
+        ProjectDetailResponse projectDetailResponse = projectService.getProjectDetail(projectId);
+        return ResponseEntity.ok().body(projectDetailResponse);
     }
 
     @GetMapping

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -5,11 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.service.ProjectService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,4 +23,11 @@ public class ProjectController {
         Long projectId = projectService.createProject(request);
         return ResponseEntity.created(URI.create("/api/project/" + projectId)).build();
     }
+
+    @GetMapping
+    public ResponseEntity<?> getAllProject() {
+
+        return ResponseEntity.ok().body(projectService.getAllProject());
+    }
+
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -1,0 +1,29 @@
+package org.devridge.api.domain.community.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.service.ProjectService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/project")
+@RequiredArgsConstructor
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @PostMapping
+    public ResponseEntity<Void> createProject(@RequestBody ProjectRequest request) {
+        Long projectId = projectService.createProject(request);
+        return ResponseEntity.created(URI.create("/api/project/" + projectId)).build();
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -6,7 +6,9 @@ import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.service.ProjectService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +30,15 @@ public class ProjectController {
     public ResponseEntity<?> getAllProject() {
 
         return ResponseEntity.ok().body(projectService.getAllProject());
+    }
+
+    @PutMapping("/{projectId}")
+    public ResponseEntity<?> updateProject(
+        @PathVariable Long projectId,
+        @RequestBody ProjectRequest request
+    ) {
+        projectService.updateProject(projectId, request);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.service.ProjectService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,4 +42,10 @@ public class ProjectController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<?> deleteProject(@PathVariable Long projectId) {
+
+        projectService.deleteProject(projectId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/CreateCommunityRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/CreateCommunityRequest.java
@@ -14,4 +14,5 @@ public class CreateCommunityRequest {
     private String content;
 
     private List<String> hashtags;
+    private List<String> images;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
@@ -1,0 +1,15 @@
+package org.devridge.api.domain.community.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+import org.devridge.api.domain.community.entity.ProjectCategory;
+
+@Getter
+public class ProjectRequest {
+
+    private String title;
+    private String content;
+    private ProjectCategory category;
+    private List<String> images;
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -1,0 +1,24 @@
+package org.devridge.api.domain.community.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public class ProjectDetailResponse {
+
+    @JsonProperty("id")
+    private Long communityId;
+
+    private String title;
+    private String content;
+    private Long views;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long likes;
+    private Long dislikes;
+
+    @JsonProperty("member")
+    private MemberInfoResponse memberInfoResponse;
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
@@ -1,0 +1,18 @@
+package org.devridge.api.domain.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ProjectListResponse {
+
+    private Long id;
+    private String category;
+    private String title;
+    private String content;
+    private Long likes;
+    private Long dislikes;
+    private Long view;
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
@@ -52,11 +52,14 @@ public class Community extends BaseEntity {
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityHashtag> hashtags = new ArrayList<>();
 
+    private String images;
+
     @Builder
-    public Community(Member member, String title, String content) {
+    public Community(Member member, String title, String content, String images) {
         this.member = member;
         this.title = title;
         this.content = content;
+        this.images = images;
     }
 
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
@@ -1,0 +1,61 @@
+package org.devridge.api.domain.community.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.devridge.api.domain.member.entity.Member;
+import org.devridge.common.entity.BaseEntity;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@DynamicInsert
+@SQLDelete(sql = "UPDATE project SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
+public class Project extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", updatable = false)
+    private Member member;
+
+    private String title;
+
+    private String content;
+
+    @ColumnDefault("0")
+    private Long views;
+
+    @ColumnDefault("0")
+    private Long likes;
+
+    @ColumnDefault("0")
+    private Long dislikes;
+
+    private String category;
+
+    private String images;
+
+    @Builder
+    public Project(Member member, String title, String content, String category, String images) {
+        this.member = member;
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.images = images;
+    }
+
+    public void updateProject(String title, String content, String category, String images) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.images = images;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/ProjectCategory.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/ProjectCategory.java
@@ -1,0 +1,17 @@
+package org.devridge.api.domain.community.entity;
+
+public enum ProjectCategory {
+    TOY_PROJECT("토이 프로젝트"),
+    PORTFOLIO_PROJECT("포트폴리오 프로젝트"),
+    ETC("기타");
+
+    private String value;
+
+    ProjectCategory(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
@@ -28,7 +28,7 @@ public class CommunityMapper {
                 .content(community.getContent())
                 .likeCount(community.getLikeCount())
                 .dislikeCount(community.getDislikeCount())
-                .views(community.getViews())
+                .views(community.getViews() + 1)
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
                 .hashtags(toHashtags(community))

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
@@ -62,6 +62,15 @@ public class CommunityMapper {
     }
 
     public Community toCommunity(Member member, CreateCommunityRequest communityRequest) {
+        if (communityRequest.getImages() != null && !communityRequest.getImages().isEmpty()) {
+            String images = communityRequest.getImages().toString();
+            return Community.builder()
+                .title(communityRequest.getTitle())
+                .content(communityRequest.getContent())
+                .member(member)
+                .images(images.substring(1, images.length() - 1))
+                .build();
+        }
         return Community.builder()
                 .title(communityRequest.getTitle())
                 .content(communityRequest.getContent())

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -3,14 +3,36 @@ package org.devridge.api.domain.community.mapper;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.dto.response.MemberInfoResponse;
+import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ProjectMapper {
+
+    private final MemberInfoMapper memberInfoMapper;
+
+    public ProjectDetailResponse toProjectDetailResponse(Project project) {
+        Member member = project.getMember();
+        MemberInfoResponse memberInfoResponse = memberInfoMapper.toMemberInfoResponse(member);
+        return ProjectDetailResponse.builder()
+                .communityId(project.getId())
+                .memberInfoResponse(memberInfoResponse)
+                .title(project.getTitle())
+                .content(project.getContent())
+                .likes(project.getLikes())
+                .dislikes(project.getDislikes())
+                .views(project.getViews() + 1)
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .build();
+    }
 
     public Project toProject(ProjectRequest request, Member member) {
         if (request.getImages() != null && !request.getImages().isEmpty()) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -30,4 +30,26 @@ public class ProjectMapper {
                 .category(request.getCategory().getValue())
                 .build();
     }
+
+    public ProjectListResponse toProjectListResponse(Project project) {
+        return ProjectListResponse.builder()
+            .id(project.getId())
+            .view(project.getViews())
+            .category(project.getCategory())
+            .likes(project.getLikes())
+            .dislikes(project.getDislikes())
+            .title(project.getTitle())
+            .content(project.getContent())
+            .build();
+    }
+
+    public List<ProjectListResponse> toProjectListResponses(List<Project> projects) {
+        List<ProjectListResponse> projectListResponses = new ArrayList<>();
+        for (Project project : projects) {
+            projectListResponses.add(
+                toProjectListResponse(project)
+            );
+        }
+        return projectListResponses;
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -1,0 +1,33 @@
+package org.devridge.api.domain.community.mapper;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.dto.response.ProjectListResponse;
+import org.devridge.api.domain.community.entity.Project;
+import org.devridge.api.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectMapper {
+
+    public Project toProject(ProjectRequest request, Member member) {
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            String images = request.getImages().toString();
+            return Project.builder()
+                    .member(member)
+                    .title(request.getTitle())
+                    .content(request.getContent())
+                    .images(images.substring(1, images.length() -1))
+                    .category(request.getCategory().getValue())
+                    .build();
+        }
+        return Project.builder()
+                .member(member)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .category(request.getCategory().getValue())
+                .build();
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectRepository.java
@@ -8,4 +8,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
+    @Modifying
+    @Query(
+        value = "UPDATE Project p " +
+            "SET p.views = p.views + 1 " +
+            "WHERE p.id = :id")
+    void updateView(@Param("id") Long id);
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectRepository.java
@@ -1,0 +1,11 @@
+package org.devridge.api.domain.community.repository;
+
+import org.devridge.api.domain.community.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentLikeDislikeService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentLikeDislikeService.java
@@ -1,6 +1,5 @@
 package org.devridge.api.domain.community.service;
 
-import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.entity.Community;
@@ -15,6 +14,7 @@ import org.devridge.api.domain.community.repository.CommunityCommentRepository;
 import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
+import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.stereotype.Service;
 
@@ -120,14 +120,14 @@ public class CommunityCommentLikeDislikeService {
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException());
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private CommunityComment getCommentById(Long commentId) {
-        return communityCommentRepository.findById(commentId).orElseThrow(() -> new EntityNotFoundException());
+        return communityCommentRepository.findById(commentId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Community getCommunityById(Long communityId) {
-        return communityRepository.findById(communityId).orElseThrow(() -> new EntityNotFoundException());
+        return communityRepository.findById(communityId).orElseThrow(() -> new DataNotFoundException());
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
@@ -1,7 +1,6 @@
 package org.devridge.api.domain.community.service;
 
 import java.util.List;
-import javax.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CommunityCommentRequest;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
@@ -13,8 +12,8 @@ import org.devridge.api.domain.community.repository.CommunityCommentRepository;
 import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
+import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -69,15 +68,15 @@ public class CommunityCommentService {
     }
 
     private CommunityComment getCommunityComment(Long commentId) {
-        return communityCommentRepository.findById(commentId).orElseThrow(() -> new EntityNotFoundException());
+        return communityCommentRepository.findById(commentId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Community getCommunityById(Long communityId) {
-        return communityRepository.findById(communityId).orElseThrow(() -> new EntityNotFoundException());
+        return communityRepository.findById(communityId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException());
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
     }
 
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityLikeDislikeService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityLikeDislikeService.java
@@ -1,6 +1,5 @@
 package org.devridge.api.domain.community.service;
 
-import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.entity.Community;
@@ -13,6 +12,7 @@ import org.devridge.api.domain.community.repository.CommunityLikeDislikeReposito
 import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
+import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.stereotype.Service;
 
@@ -105,11 +105,11 @@ public class CommunityLikeDislikeService {
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException());
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Community getCommunityById(Long communityId) {
-        return communityRepository.findById(communityId).orElseThrow(() -> new EntityNotFoundException());
+        return communityRepository.findById(communityId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private void updateLikeDislike(Long communityId) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityScrapService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityScrapService.java
@@ -1,6 +1,5 @@
 package org.devridge.api.domain.community.service;
 
-import javax.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.entity.Community;
 import org.devridge.api.domain.community.entity.CommunityScrap;
@@ -11,8 +10,8 @@ import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.community.repository.CommunityScrapRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
+import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,11 +53,11 @@ public class CommunityScrapService {
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException());
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Community getCommunityById(Long communityId) {
-        return communityRepository.findById(communityId).orElseThrow(() -> new EntityNotFoundException());
+        return communityRepository.findById(communityId).orElseThrow(() -> new DataNotFoundException());
     }
 
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -19,7 +19,6 @@ import org.devridge.api.domain.community.repository.HashtagRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.util.SecurityContextHolderUtil;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,8 +41,8 @@ public class CommunityService {
 
     @Transactional
     public CommunityDetailResponse getCommunity(Long communityId) {
-        updateView(communityId);
         Community community = getCommunityById(communityId);
+        communityRepository.updateView(communityId);
         return communityMapper.toCommunityDetailResponse(community);
     }
 
@@ -79,10 +78,6 @@ public class CommunityService {
     public List<CommunityListResponse> getAllCommunity() {
         List<Community> communities = communityRepository.findAll();
         return communityMapper.toCommunityListResponses(communities);
-    }
-
-    private void updateView(Long id) {
-        communityRepository.updateView(id);
     }
 
     private Community getCommunityById(Long communityId) {
@@ -145,7 +140,7 @@ public class CommunityService {
             .collect(Collectors.toList());
     }
 
-    private CommunityHashtag saveOrRestoreCommunityHashtag(Community community, Hashtag hashtag) {
+    private CommunityHashtag saveOrRestoreCommunityHashtag(Community community, Hashtag hashtag) {  // 소프트 딜리트 포함 가져오기  -> 다 지워진상태or 없는상태 위에서 다지움
         return communityHashtagRepository.findByCommunityIdAndHashtagId(community.getId(), hashtag.getId())
             .map(result -> {
                 communityHashtagRepository.restoreByCommunityIdAndHashtagId(community.getId(), hashtag.getId());

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -3,7 +3,6 @@ package org.devridge.api.domain.community.service;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CreateCommunityRequest;
 import org.devridge.api.domain.community.dto.response.CommunityDetailResponse;
@@ -20,6 +19,7 @@ import org.devridge.api.domain.community.repository.HashtagRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.domain.s3.service.S3Service;
+import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,11 +86,11 @@ public class CommunityService {
     }
 
     private Community getCommunityById(Long communityId) {
-        return communityRepository.findById(communityId).orElseThrow(() -> new EntityNotFoundException());
+        return communityRepository.findById(communityId).orElseThrow(() -> new DataNotFoundException());
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException());
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
     }
 
     @Transactional

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -76,8 +76,10 @@ public class CommunityService {
         updateByHashtagIds(communityHashtags);
 
         communityRepository.deleteById(communityId);
-        List<String> images = Arrays.asList(community.getImages().split(", "));
-        s3Service.deleteAllImage(images);
+        if (community.getImages() != null) {
+            List<String> images = Arrays.asList(community.getImages().split(", "));
+            s3Service.deleteAllImage(images);
+        }
     }
 
     public List<CommunityListResponse> getAllCommunity() {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -59,7 +59,13 @@ public class ProjectService {
 
         if (request.getImages() != null && !request.getImages().isEmpty()) {
             String images = request.getImages().toString();
-            project.updateProject(request.getTitle(), request.getContent(), request.getCategory().getValue(), images.substring(1, images.length() - 1));
+
+            project.updateProject(
+                request.getTitle(),
+                request.getContent(),
+                request.getCategory().getValue(),
+                images.substring(1, images.length() - 1)
+            );
             return;
         }
         project.updateProject(request.getTitle(), request.getContent(), request.getCategory().getValue(), null);
@@ -82,7 +88,7 @@ public class ProjectService {
         }
     }
 
-    public Project getProjectById(Long projectId) {
+    private Project getProjectById(Long projectId) {
         return projectRepository.findById(projectId).orElseThrow(() -> new DataNotFoundException());
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -12,6 +12,7 @@ import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +35,17 @@ public class ProjectService {
         return projectMapper.toProjectListResponses(project);
     }
 
+    @Transactional
+    public void updateProject(Long projectId, ProjectRequest request) {
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new DataNotFoundException());
 
+        if (request.getImages() != null && !request.getImages().isEmpty()) {
+            String images = request.getImages().toString();
+            project.updateProject(request.getTitle(), request.getContent(), request.getCategory().getValue(), images.substring(1, images.length() - 1));
+            return;
+        }
+        project.updateProject(request.getTitle(), request.getContent(), request.getCategory().getValue(), null);
+    }
 
     private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -1,6 +1,5 @@
 package org.devridge.api.domain.community.service;
 
-import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
@@ -10,11 +9,9 @@ import org.devridge.api.domain.community.mapper.ProjectMapper;
 import org.devridge.api.domain.community.repository.ProjectRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
-import org.devridge.api.domain.s3.service.S3Service;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +28,13 @@ public class ProjectService {
         Project project = projectMapper.toProject(request, member);
         return projectRepository.save(project).getId();
     }
+
+    public List<ProjectListResponse> getAllProject() {
+        List<Project> project = projectRepository.findAll();
+        return projectMapper.toProjectListResponses(project);
+    }
+
+
 
     private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -1,0 +1,38 @@
+package org.devridge.api.domain.community.service;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.dto.response.ProjectListResponse;
+import org.devridge.api.domain.community.entity.Project;
+import org.devridge.api.domain.community.mapper.ProjectMapper;
+import org.devridge.api.domain.community.repository.ProjectRepository;
+import org.devridge.api.domain.member.entity.Member;
+import org.devridge.api.domain.member.repository.MemberRepository;
+import org.devridge.api.domain.s3.service.S3Service;
+import org.devridge.api.exception.common.DataNotFoundException;
+import org.devridge.api.util.SecurityContextHolderUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMapper projectMapper;
+    private final MemberRepository memberRepository;
+
+    public Long createProject(ProjectRequest request) {
+        Long accessMemberId = SecurityContextHolderUtil.getMemberId();
+        Member member = getMemberById(accessMemberId);
+
+        Project project = projectMapper.toProject(request, member);
+        return projectRepository.save(project).getId();
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new DataNotFoundException());
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
+import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
@@ -32,6 +33,13 @@ public class ProjectService {
 
         Project project = projectMapper.toProject(request, member);
         return projectRepository.save(project).getId();
+    }
+
+    @Transactional
+    public ProjectDetailResponse getProjectDetail(Long projectId) {
+        Project project = getProjectById(projectId);
+        projectRepository.updateView(projectId);
+        return projectMapper.toProjectDetailResponse(project);
     }
 
     public List<ProjectListResponse> getAllProject() {

--- a/api-module/src/main/java/org/devridge/api/domain/s3/validator/type/ImagePath.java
+++ b/api-module/src/main/java/org/devridge/api/domain/s3/validator/type/ImagePath.java
@@ -1,5 +1,7 @@
 package org.devridge.api.domain.s3.validator.type;
 
 public enum ImagePath {
-    qna, member
+    qna,
+    member,
+    community
 }


### PR DESCRIPTION
## Description ✍️
* 커뮤니티 이슈 게시글에 이미지 첨부, 삭제 기능
* 커뮤니티의 프로젝트 게시글에 crud, 이미지 첨부, 삭제 api 추가

## 테스트 시 유의사항 ⚠️
* postman에 올려두었습니다.

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?