### PR TITLE
무한스크롤 구현 및 화면 변경에 따른 Community API 수정 및 리팩토링합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityCommentController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityCommentController.java
@@ -1,12 +1,14 @@
 package org.devridge.api.domain.community.controller;
 
 import java.net.URI;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CommunityCommentRequest;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
 import org.devridge.api.domain.community.service.CommunityCommentService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -33,9 +36,19 @@ public class CommunityCommentController {
         return ResponseEntity.created(URI.create("/api/community/" + communityId + "/comments/" + commentId)).build();
     }
 
+//    @GetMapping
+//    public ResponseEntity<List<CommunityCommentResponse>> getAllComments(@PathVariable Long communityId) {
+//        List<CommunityCommentResponse> commentResponses = communityCommentService.getAllComment(communityId);
+//        return ResponseEntity.ok().body(commentResponses);
+//    }
+
     @GetMapping
-    public ResponseEntity<List<CommunityCommentResponse>> getAllComments(@PathVariable Long communityId) {
-        List<CommunityCommentResponse> commentResponses = communityCommentService.getAllComment(communityId);
+    public ResponseEntity<Slice<CommunityCommentResponse>> getAllComments(
+        @PathVariable Long communityId,
+        @RequestParam(name = "lastId", required = false) Long lastId,
+        @PageableDefault( ) Pageable pageable
+    ) {
+        Slice<CommunityCommentResponse> commentResponses = communityCommentService.getAllCommunityComment(communityId, lastId, pageable);
         return ResponseEntity.ok().body(commentResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityCommentController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityCommentController.java
@@ -36,12 +36,6 @@ public class CommunityCommentController {
         return ResponseEntity.created(URI.create("/api/community/" + communityId + "/comments/" + commentId)).build();
     }
 
-//    @GetMapping
-//    public ResponseEntity<List<CommunityCommentResponse>> getAllComments(@PathVariable Long communityId) {
-//        List<CommunityCommentResponse> commentResponses = communityCommentService.getAllComment(communityId);
-//        return ResponseEntity.ok().body(commentResponses);
-//    }
-
     @GetMapping
     public ResponseEntity<Slice<CommunityCommentResponse>> getAllComments(
         @PathVariable Long communityId,

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
@@ -5,7 +5,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CreateCommunityRequest;
 import org.devridge.api.domain.community.dto.response.CommunityDetailResponse;
-import org.devridge.api.domain.community.dto.response.CommunityListResponse;
+import org.devridge.api.domain.community.dto.response.CommunitySliceResponse;
 import org.devridge.api.domain.community.service.CommunityService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -62,12 +62,12 @@ public class CommunityController {
 //    }
 
     @GetMapping
-    public ResponseEntity<Slice<CommunityListResponse>> getAllCommunity(
+    public ResponseEntity<Slice<CommunitySliceResponse>> getAllCommunity(
         @RequestParam(name = "lastId", required = false) Long lastId,
         @PageableDefault( ) Pageable pageable
     ) {
-        Slice<CommunityListResponse> communityListResponses = communityService.getAllCommunity(lastId, pageable);
-        return ResponseEntity.ok().body(communityListResponses);
+        Slice<CommunitySliceResponse> communitySliceResponses = communityService.getAllCommunity(lastId, pageable);
+        return ResponseEntity.ok().body(communitySliceResponses);
     }
 }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
@@ -1,13 +1,15 @@
 package org.devridge.api.domain.community.controller;
 
 import java.net.URI;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CreateCommunityRequest;
 import org.devridge.api.domain.community.dto.response.CommunityDetailResponse;
 import org.devridge.api.domain.community.dto.response.CommunityListResponse;
 import org.devridge.api.domain.community.service.CommunityService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -52,9 +55,18 @@ public class CommunityController {
         return ResponseEntity.ok().build();
     }
 
+//    @GetMapping
+//    public ResponseEntity<List<CommunityListResponse>> getAllCommunity() {
+//        List<CommunityListResponse> communityListResponses = communityService.getAllCommunity();
+//        return ResponseEntity.ok().body(communityListResponses);
+//    }
+
     @GetMapping
-    public ResponseEntity<List<CommunityListResponse>> getAllCommunity() {
-        List<CommunityListResponse> communityListResponses = communityService.getAllCommunity();
+    public ResponseEntity<Slice<CommunityListResponse>> getAllCommunity(
+        @RequestParam(name = "lastId", required = false) Long lastId,
+        @PageableDefault( ) Pageable pageable
+    ) {
+        Slice<CommunityListResponse> communityListResponses = communityService.getAllCommunity(lastId, pageable);
         return ResponseEntity.ok().body(communityListResponses);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/CommunityController.java
@@ -55,12 +55,6 @@ public class CommunityController {
         return ResponseEntity.ok().build();
     }
 
-//    @GetMapping
-//    public ResponseEntity<List<CommunityListResponse>> getAllCommunity() {
-//        List<CommunityListResponse> communityListResponses = communityService.getAllCommunity();
-//        return ResponseEntity.ok().body(communityListResponses);
-//    }
-
     @GetMapping
     public ResponseEntity<Slice<CommunitySliceResponse>> getAllCommunity(
         @RequestParam(name = "lastId", required = false) Long lastId,

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -1,12 +1,13 @@
 package org.devridge.api.domain.community.controller;
 
 import java.net.URI;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.service.ProjectService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,9 +38,18 @@ public class ProjectController {
         return ResponseEntity.ok().body(projectDetailResponse);
     }
 
+//    @GetMapping
+//    public ResponseEntity<List<ProjectListResponse>> getAllProject() {
+//        List<ProjectListResponse> projectListResponses = projectService.getAllProject();
+//        return ResponseEntity.ok().body(projectListResponses);
+//    }
+
     @GetMapping
-    public ResponseEntity<List<ProjectListResponse>> getAllProject() {
-        List<ProjectListResponse> projectListResponses = projectService.getAllProject();
+    public ResponseEntity<Slice<ProjectListResponse>> getAllCommunity(
+        @RequestParam(name = "lastId", required = false) Long lastId,
+        Pageable pageable
+    ) {
+        Slice<ProjectListResponse> projectListResponses = projectService.getAllProject(lastId, pageable);
         return ResponseEntity.ok().body(projectListResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -45,7 +45,7 @@ public class ProjectController {
 //    }
 
     @GetMapping
-    public ResponseEntity<Slice<ProjectListResponse>> getAllCommunity(
+    public ResponseEntity<Slice<ProjectListResponse>> getAllProject(
         @RequestParam(name = "lastId", required = false) Long lastId,
         Pageable pageable
     ) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -39,12 +39,6 @@ public class ProjectController {
         return ResponseEntity.ok().body(projectDetailResponse);
     }
 
-//    @GetMapping
-//    public ResponseEntity<List<ProjectListResponse>> getAllProject() {
-//        List<ProjectListResponse> projectListResponses = projectService.getAllProject();
-//        return ResponseEntity.ok().body(projectListResponses);
-//    }
-
     @GetMapping
     public ResponseEntity<Slice<ProjectListResponse>> getAllProject(
         @RequestParam(name = "lastId", required = false) Long lastId,

--- a/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package org.devridge.api.domain.community.controller;
 
 import java.net.URI;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
@@ -27,7 +28,7 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping
-    public ResponseEntity<Void> createProject(@RequestBody ProjectRequest request) {
+    public ResponseEntity<Void> createProject(@Valid @RequestBody ProjectRequest request) {
         Long projectId = projectService.createProject(request);
         return ResponseEntity.created(URI.create("/api/community/projects/" + projectId)).build();
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/CreateCommunityRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/CreateCommunityRequest.java
@@ -14,5 +14,6 @@ public class CreateCommunityRequest {
     private String content;
 
     private List<String> hashtags;
+
     private List<String> images;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
@@ -15,4 +15,5 @@ public class ProjectRequest {
 
     private List<Long> skillIds;
     private Meeting meeting;
+    private Boolean isRecruiting;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
@@ -2,6 +2,7 @@ package org.devridge.api.domain.community.dto.request;
 
 import java.util.List;
 import lombok.Getter;
+import org.devridge.api.domain.community.entity.Meeting;
 import org.devridge.api.domain.community.entity.ProjectCategory;
 
 @Getter
@@ -12,4 +13,6 @@ public class ProjectRequest {
     private ProjectCategory category;
     private List<String> images;
 
+    private List<Long> skillIds;
+    private Meeting meeting;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
@@ -4,16 +4,22 @@ import java.util.List;
 import lombok.Getter;
 import org.devridge.api.domain.community.entity.Meeting;
 import org.devridge.api.domain.community.entity.ProjectCategory;
+import org.devridge.api.domain.community.validator.ValidateEnum;
 
 @Getter
 public class ProjectRequest {
 
     private String title;
     private String content;
-    private ProjectCategory category;
-    private List<String> images;
 
+    @ValidateEnum(enumClass = ProjectCategory.class, message = "category에 없는 값입니다.")
+    private String category;
+
+    private List<String> images;
     private List<Long> skillIds;
-    private Meeting meeting;
+
+    @ValidateEnum(enumClass = Meeting.class, message = "meeting에 없는 값입니다.")
+    private String meeting;
+
     private Boolean isRecruiting;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/ProjectRequest.java
@@ -1,6 +1,7 @@
 package org.devridge.api.domain.community.dto.request;
 
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import org.devridge.api.domain.community.entity.Meeting;
 import org.devridge.api.domain.community.entity.ProjectCategory;
@@ -9,13 +10,17 @@ import org.devridge.api.domain.community.validator.ValidateEnum;
 @Getter
 public class ProjectRequest {
 
+    @NotNull
     private String title;
+
+    @NotNull
     private String content;
 
     @ValidateEnum(enumClass = ProjectCategory.class, message = "category에 없는 값입니다.")
     private String category;
 
     private List<String> images;
+
     private List<Long> skillIds;
 
     @ValidateEnum(enumClass = Meeting.class, message = "meeting에 없는 값입니다.")

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityCommentResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityCommentResponse.java
@@ -2,12 +2,14 @@ package org.devridge.api.domain.community.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 
 @Builder
 @Getter
+@AllArgsConstructor
 public class CommunityCommentResponse {
 
     @JsonProperty("id")

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityCommentResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityCommentResponse.java
@@ -16,9 +16,13 @@ public class CommunityCommentResponse {
     private Long commentId;
 
     private String content;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
+
     private Long likeCount;
+
     private Long dislikeCount;
 
     @JsonProperty("member")

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
@@ -15,7 +15,7 @@ public class CommunityDetailResponse {
 
     private String title;
     private String content;
-    private Long views;
+    private Long viewCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long likeCount;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
@@ -14,11 +14,17 @@ public class CommunityDetailResponse {
     private Long communityId;
 
     private String title;
+
     private String content;
+
     private Long viewCount;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
+
     private Long likeCount;
+
     private Long dislikeCount;
 
     @JsonProperty("member")

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
@@ -11,5 +11,5 @@ public class CommunityListResponse {
     private String title;
     private Long views;
     private Long likeCount;
-    private Long comments;
+    private Long commentCount;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
@@ -1,15 +1,17 @@
 package org.devridge.api.domain.community.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class CommunityListResponse {
 
     private Long id;
     private String title;
     private Long views;
     private Long likeCount;
-    private Long commentCount;
+    private Long comments;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
@@ -9,7 +9,7 @@ public class CommunityListResponse {
 
     private Long id;
     private String title;
-    private Long views;
+    private Long viewCount;
     private Long likeCount;
     private Long commentCount;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityListResponse.java
@@ -1,12 +1,10 @@
 package org.devridge.api.domain.community.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class CommunityListResponse {
 
     private Long id;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -2,13 +2,9 @@ package org.devridge.api.domain.community.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
-@AllArgsConstructor
 public class CommunitySliceResponse {
     private Long id;
     private String title;
@@ -20,4 +16,8 @@ public class CommunitySliceResponse {
     private LocalDateTime updatedAt;
     private List<HashtagResponse> hashtags;
     private Long scraps;
+
+    public void setHashtags(List<HashtagResponse> hashtags) {
+        this.hashtags = hashtags;
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -1,0 +1,20 @@
+package org.devridge.api.domain.community.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommunitySliceResponse {
+    private Long id;
+    private String title;
+    private Long views;
+    private Long likeCount;
+    private Long comments;
+    private MemberInfoResponse member;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<HashtagResponse> hashtags;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class CommunitySliceResponse {
     private Long id;
     private String title;
-    private Long views;
+    private Long viewCount;
     private Long likeCount;
     private Long comments;
     private MemberInfoResponse member;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -17,4 +17,5 @@ public class CommunitySliceResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<HashtagResponse> hashtags;
+    private Long scraps;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -2,11 +2,13 @@ package org.devridge.api.domain.community.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class CommunitySliceResponse {
     private Long id;
     private String title;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/HashtagResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/HashtagResponse.java
@@ -1,15 +1,12 @@
 package org.devridge.api.domain.community.dto.response;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
 public class HashtagResponse {
 
     private Long id;
     private String word;
-    private Long count;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/HashtagResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/HashtagResponse.java
@@ -1,0 +1,15 @@
+package org.devridge.api.domain.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HashtagResponse {
+
+    private Long id;
+    private String word;
+    private Long count;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/MemberInfoResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/MemberInfoResponse.java
@@ -1,11 +1,13 @@
 package org.devridge.api.domain.community.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class MemberInfoResponse {
 
     @JsonProperty("id")

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/MemberInfoResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/MemberInfoResponse.java
@@ -15,6 +15,8 @@ public class MemberInfoResponse {
 
     @JsonProperty("nickname")
     private String nickName;
+
     private String profileImageUrl;
+
     private String introduction;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -14,19 +14,27 @@ public class ProjectDetailResponse {
     private Long communityId;
 
     private String title;
+
     private String content;
+
     private Long views;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
+
     private Long likes;
+
     private Long dislikes;
 
     @JsonProperty("member")
     private MemberInfoResponse memberInfoResponse;
 
     private String category;
-    private List<String> skills;
-    private String meeting;
-    private Boolean isRecruiting;
 
+    private List<String> skills;
+
+    private String meeting;
+
+    private Boolean isRecruiting;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -2,9 +2,12 @@ package org.devridge.api.domain.community.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class ProjectDetailResponse {
 
     @JsonProperty("id")
@@ -20,5 +23,9 @@ public class ProjectDetailResponse {
 
     @JsonProperty("member")
     private MemberInfoResponse memberInfoResponse;
+
+    private String category;
+    private List<String> skills;
+    private String meeting;
 
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -27,5 +27,6 @@ public class ProjectDetailResponse {
     private String category;
     private List<String> skills;
     private String meeting;
+    private Boolean isRecruiting;
 
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
@@ -1,10 +1,12 @@
 package org.devridge.api.domain.community.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
+@AllArgsConstructor
 public class ProjectListResponse {
 
     private Long id;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
@@ -1,5 +1,6 @@
 package org.devridge.api.domain.community.dto.response;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,5 +17,7 @@ public class ProjectListResponse {
     private Long likes;
     private Long dislikes;
     private Long view;
-
+    private Boolean isRecruiting;
+    private List<String> skills;
+    private String meeting;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
@@ -4,10 +4,12 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class ProjectListResponse {
 
     private Long id;
@@ -16,8 +18,12 @@ public class ProjectListResponse {
     private String content;
     private Long likes;
     private Long dislikes;
-    private Long view;
+    private Long views;
     private Boolean isRecruiting;
-    private List<String> skills;
+    private List<SkillResponse> skills;
     private String meeting;
+
+    public void setSkills(List<SkillResponse> skills) {
+        this.skills = skills;
+    }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/SkillResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/SkillResponse.java
@@ -1,0 +1,11 @@
+package org.devridge.api.domain.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SkillResponse {
+    private Long id;
+    private String skill;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
@@ -13,14 +13,23 @@ public class StudyDetailResponse {
     private Long studyId;
 
     private String title;
+
     private String content;
+
     private Long views;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
+
     private Long likes;
+
     private Long dislikes;
+
     private String location;
+
     private Integer totalPeople;
+
     private Integer currentPeople;
 
     @JsonProperty("member")

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
@@ -52,6 +52,9 @@ public class Community extends BaseEntity {
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityHashtag> hashtags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "community", cascade = CascadeType.ALL)
+    private List<CommunityScrap> scraps = new ArrayList<>();
+
     private String images;
 
     @Builder

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Community.java
@@ -38,7 +38,7 @@ public class Community extends BaseEntity {
     private String content;
 
     @ColumnDefault("0")
-    private Long views;
+    private Long viewCount;
 
     @ColumnDefault("0")
     private Long likeCount;

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Meeting.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Meeting.java
@@ -1,0 +1,6 @@
+package org.devridge.api.domain.community.entity;
+
+public enum Meeting {
+    온라인,
+    오프라인
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
@@ -1,13 +1,17 @@
 package org.devridge.api.domain.community.entity;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devridge.api.domain.member.entity.Member;
+import org.devridge.api.domain.skill.entity.ProjectSkill;
 import org.devridge.common.entity.BaseEntity;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
@@ -43,14 +47,22 @@ public class Project extends BaseEntity {
 
     private String images;
 
+    @OneToMany(mappedBy = "project")
+    private List<ProjectSkill> projectSkills = new ArrayList<>();
+
+    private String meeting;
+
     @Builder
-    public Project(Member member, String title, String content, String category, String images) {
+    public Project(Member member, String title, String content, String category, String images, String meeting) {
         this.member = member;
         this.title = title;
         this.content = content;
         this.category = category;
         this.images = images;
+        this.meeting = meeting;
     }
+
+
 
     public void updateProject(String title, String content, String category, String images) {
         this.title = title;

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
@@ -2,6 +2,7 @@ package org.devridge.api.domain.community.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -52,14 +53,19 @@ public class Project extends BaseEntity {
 
     private String meeting;
 
+    @Column(columnDefinition = "TINYINT(1)")
+    @ColumnDefault("true")
+    private Boolean isRecruiting;
+
     @Builder
-    public Project(Member member, String title, String content, String category, String images, String meeting) {
+    public Project(Member member, String title, String content, String category, String images, String meeting, Boolean isRecruiting) {
         this.member = member;
         this.title = title;
         this.content = content;
         this.category = category;
         this.images = images;
         this.meeting = meeting;
+        this.isRecruiting = isRecruiting;
     }
 
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
@@ -2,6 +2,7 @@ package org.devridge.api.domain.community.entity;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -48,7 +49,7 @@ public class Project extends BaseEntity {
 
     private String images;
 
-    @OneToMany(mappedBy = "project")
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<ProjectSkill> projectSkills = new ArrayList<>();
 
     private String meeting;
@@ -70,10 +71,12 @@ public class Project extends BaseEntity {
 
 
 
-    public void updateProject(String title, String content, String category, String images) {
+    public void updateProject(String title, String content, String category, String images, String meeting, Boolean isRecruiting) {
         this.title = title;
         this.content = content;
         this.category = category;
         this.images = images;
+        this.meeting = meeting;
+        this.isRecruiting = isRecruiting;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/ProjectCategory.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/ProjectCategory.java
@@ -1,17 +1,7 @@
 package org.devridge.api.domain.community.entity;
 
 public enum ProjectCategory {
-    TOY_PROJECT("토이 프로젝트"),
-    PORTFOLIO_PROJECT("포트폴리오 프로젝트"),
-    ETC("기타");
-
-    private String value;
-
-    ProjectCategory(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
+    TOY_PROJECT,
+    PORTFOLIO_PROJECT,
+    ETC
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
@@ -28,7 +28,7 @@ public class CommunityMapper {
                 .content(community.getContent())
                 .likeCount(community.getLikeCount())
                 .dislikeCount(community.getDislikeCount())
-                .views(community.getViewCount() + 1)
+                .viewCount(community.getViewCount() + 1)
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
                 .hashtags(toHashtags(community))
@@ -46,7 +46,7 @@ public class CommunityMapper {
                 .id(community.getId())
                 .title(community.getTitle())
                 .commentCount(Long.valueOf(community.getComments().size()))
-                .views(community.getViewCount())
+                .viewCount(community.getViewCount())
                 .likeCount(community.getLikeCount())
                 .build();
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
@@ -28,7 +28,7 @@ public class CommunityMapper {
                 .content(community.getContent())
                 .likeCount(community.getLikeCount())
                 .dislikeCount(community.getDislikeCount())
-                .views(community.getViews() + 1)
+                .views(community.getViewCount() + 1)
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
                 .hashtags(toHashtags(community))
@@ -45,8 +45,8 @@ public class CommunityMapper {
         return CommunityListResponse.builder()
                 .id(community.getId())
                 .title(community.getTitle())
-                .comments(Long.valueOf(community.getComments().size()))
-                .views(community.getViews())
+                .commentCount(Long.valueOf(community.getComments().size()))
+                .views(community.getViewCount())
                 .likeCount(community.getLikeCount())
                 .build();
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/CommunityMapper.java
@@ -45,7 +45,7 @@ public class CommunityMapper {
         return CommunityListResponse.builder()
                 .id(community.getId())
                 .title(community.getTitle())
-                .commentCount(Long.valueOf(community.getComments().size()))
+                .comments(Long.valueOf(community.getComments().size()))
                 .views(community.getViews())
                 .likeCount(community.getLikeCount())
                 .build();

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -18,7 +18,7 @@ public class ProjectMapper {
 
     private final MemberInfoMapper memberInfoMapper;
 
-    public ProjectDetailResponse toProjectDetailResponse(Project project) {
+    public ProjectDetailResponse toProjectDetailResponse(Project project, List<String> skills) {
         Member member = project.getMember();
         MemberInfoResponse memberInfoResponse = memberInfoMapper.toMemberInfoResponse(member);
         return ProjectDetailResponse.builder()
@@ -31,6 +31,9 @@ public class ProjectMapper {
                 .views(project.getViews() + 1)
                 .createdAt(project.getCreatedAt())
                 .updatedAt(project.getUpdatedAt())
+                .category(project.getCategory())
+                .meeting(project.getMeeting())
+                .skills(skills)
                 .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -43,6 +43,7 @@ public class ProjectMapper {
                     .content(request.getContent())
                     .images(images.substring(1, images.length() -1))
                     .category(request.getCategory().getValue())
+                    .meeting(request.getMeeting().toString())
                     .build();
         }
         return Project.builder()
@@ -50,6 +51,7 @@ public class ProjectMapper {
                 .title(request.getTitle())
                 .content(request.getContent())
                 .category(request.getCategory().getValue())
+                .meeting(request.getMeeting().toString())
                 .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -62,7 +62,7 @@ public class ProjectMapper {
     public ProjectListResponse toProjectListResponse(Project project) {
         return ProjectListResponse.builder()
             .id(project.getId())
-            .view(project.getViews())
+            .views(project.getViews())
             .category(project.getCategory())
             .likes(project.getLikes())
             .dislikes(project.getDislikes())

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -46,16 +46,16 @@ public class ProjectMapper {
                     .title(request.getTitle())
                     .content(request.getContent())
                     .images(images.substring(1, images.length() -1))
-                    .category(request.getCategory().getValue())
-                    .meeting(request.getMeeting().toString())
+                    .category(request.getCategory())
+                    .meeting(request.getMeeting())
                     .build();
         }
         return Project.builder()
                 .member(member)
                 .title(request.getTitle())
                 .content(request.getContent())
-                .category(request.getCategory().getValue())
-                .meeting(request.getMeeting().toString())
+                .category(request.getCategory())
+                .meeting(request.getMeeting())
                 .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/mapper/ProjectMapper.java
@@ -34,6 +34,7 @@ public class ProjectMapper {
                 .category(project.getCategory())
                 .meeting(project.getMeeting())
                 .skills(skills)
+                .isRecruiting(project.getIsRecruiting())
                 .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityCommentQuerydslReopsitory.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityCommentQuerydslReopsitory.java
@@ -1,0 +1,99 @@
+package org.devridge.api.domain.community.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
+import org.devridge.api.domain.community.dto.response.MemberInfoResponse;
+import org.devridge.api.domain.community.entity.CommunityComment;
+import org.devridge.api.domain.community.entity.QCommunityComment;
+import org.devridge.api.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityCommentQuerydslReopsitory {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private QCommunityComment comment = QCommunityComment.communityComment;
+
+    public Slice<CommunityCommentResponse> searchBySlice(Long communityId, Long lastId, Pageable pageable) {
+        List<CommunityComment> lists = jpaQueryFactory
+            .select(comment)
+            .from(comment)
+            .leftJoin(comment.member)
+            .where(
+                ltId(lastId),
+                comment.isDeleted.eq(false),
+                comment.community.id.eq(communityId)
+            )
+            .orderBy(comment.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        List<CommunityCommentResponse> results = new ArrayList<>();
+
+
+        for (CommunityComment comment : lists) {
+            MemberInfoResponse memberInfoResponse;
+            try {
+                Member member = comment.getMember();
+                 memberInfoResponse = MemberInfoResponse.builder()
+                        .memberId(member.getId())
+                        .nickName(member.getNickname())
+                        .profileImageUrl(member.getProfileImageUrl())
+                        .introduction(member.getIntroduction())
+                        .build();
+            } catch (EntityNotFoundException e) {
+                 memberInfoResponse = MemberInfoResponse.builder()
+                        .memberId(0L)
+                        .nickName("기본 닉네임")
+                        .profileImageUrl("기본 프로필 이미지 URL")
+                        .introduction("기본 소개")
+                        .build();
+            }
+
+            results.add(
+                CommunityCommentResponse.builder()
+                    .commentId(comment.getId())
+                    .content(comment.getContent())
+                    .createdAt(comment.getCreatedAt())
+                    .updatedAt(comment.getUpdatedAt())
+                    .likeCount(comment.getLikeCount())
+                    .dislikeCount(comment.getDislikeCount())
+                    .memberInfoResponse(memberInfoResponse)
+                    .build()
+            );
+        }
+        return checkLastPage(pageable, results);
+    }
+
+    // no-offset 방식 처리하는 메서드
+    private BooleanExpression ltId(Long communityId) {
+        if (communityId == null) {
+            return null;
+        }
+
+        return comment.id.lt(communityId);
+    }
+
+    private Slice<CommunityCommentResponse> checkLastPage(Pageable pageable, List<CommunityCommentResponse> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.response.CommunitySliceResponse;
@@ -12,6 +13,7 @@ import org.devridge.api.domain.community.dto.response.HashtagResponse;
 import org.devridge.api.domain.community.dto.response.MemberInfoResponse;
 import org.devridge.api.domain.community.entity.QCommunity;
 import org.devridge.api.domain.community.entity.QCommunityHashtag;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -27,60 +29,67 @@ public class CommunityQuerydslRepository {
 
 
     public Slice<CommunitySliceResponse> searchBySlice(Long lastId, Pageable pageable) {
-        List<CommunitySliceResponse> results = jpaQueryFactory
-            .selectFrom(community)
-            .leftJoin(community.member)
-            .leftJoin(community.hashtags, communityHashtag)
-            .leftJoin(communityHashtag.hashtag)
-            .where(
-                ltId(lastId),
-                community.isDeleted.eq(false)
-            )
-            .orderBy(community.id.desc())
-            .limit(pageable.getPageSize() + 1)
-            .transform(GroupBy.groupBy(community.id)
-                .list(Projections.constructor(
-                    CommunitySliceResponse.class,
-                    community.id,
-                    community.title,
-                    community.views,
-                    community.likeCount,
-                    community.comments.size().longValue(),
+        List<CommunitySliceResponse> results = new ArrayList<>();
 
-                    Projections.constructor(
-                        MemberInfoResponse.class,
-                        Expressions.cases()
-                            .when(community.member.nickname.isNull())
-                            .then(0L)
-                            .otherwise(community.member.id),
-                        Expressions.cases()
-                            .when(community.member.nickname.isNull())
-                            .then("DefaultNickname")
-                            .otherwise(community.member.nickname),
-                        Expressions.cases()
-                            .when(community.member.nickname.isNull())
-                            .then("DefaultUrl")
-                            .otherwise(community.member.profileImageUrl),
-                        Expressions.cases()
-                            .when(community.member.nickname.isNull())
-                            .then("DefaultIntroduction")
-                            .otherwise(community.member.introduction)
-                    ),
+        while (results.size() <= 10) {
+            List<CommunitySliceResponse> result = jpaQueryFactory
+                .selectFrom(community)
+                .leftJoin(community.member)
+                .leftJoin(community.hashtags, communityHashtag)
+                .leftJoin(communityHashtag.hashtag)
+                .where(
+                    ltId(lastId),
+                    community.isDeleted.eq(false)
+                )
+                .orderBy(community.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .transform(GroupBy.groupBy(community.id)
+                    .list(Projections.constructor(
+                        CommunitySliceResponse.class,
+                        community.id,
+                        community.title,
+                        community.views,
+                        community.likeCount,
+                        community.comments.size().longValue(),
 
-                    community.createdAt,
-                    community.updatedAt,
+                        Projections.constructor(
+                            MemberInfoResponse.class,
+                            Expressions.cases()
+                                .when(community.member.nickname.isNull())
+                                .then(0L)
+                                .otherwise(community.member.id),
+                            Expressions.cases()
+                                .when(community.member.nickname.isNull())
+                                .then("DefaultNickname")
+                                .otherwise(community.member.nickname),
+                            Expressions.cases()
+                                .when(community.member.nickname.isNull())
+                                .then("DefaultUrl")
+                                .otherwise(community.member.profileImageUrl),
+                            Expressions.cases()
+                                .when(community.member.nickname.isNull())
+                                .then("DefaultIntroduction")
+                                .otherwise(community.member.introduction)
+                        ),
 
-                    GroupBy.list(Projections.fields(
-                        HashtagResponse.class,
-                        communityHashtag.hashtag.id,
-                        communityHashtag.hashtag.word,
-                        communityHashtag.hashtag.count
+                        community.createdAt,
+                        community.updatedAt,
+
+                        GroupBy.list(Projections.fields(
+                            HashtagResponse.class,
+                            communityHashtag.hashtag.id,
+                            communityHashtag.hashtag.word,
+                            communityHashtag.hashtag.count
                         )),
 
-                    community.scraps.size().longValue()
-                ))
-            );
-        return checkLastPage(pageable, results);
+                        community.scraps.size().longValue()
+                    ))
+                );
+            results.addAll(result);
+        }
+
+        Pageable customPageable = PageRequest.of(0 , results.size() - 1, pageable.getSort());
+        return checkLastPage(customPageable, results);
     }
 
     // no-offset 방식 처리하는 메서드

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -1,12 +1,19 @@
 package org.devridge.api.domain.community.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.devridge.api.domain.community.dto.response.CommunityListResponse;
+import org.devridge.api.domain.community.dto.response.CommunitySliceResponse;
+import org.devridge.api.domain.community.dto.response.HashtagResponse;
+import org.devridge.api.domain.community.dto.response.MemberInfoResponse;
 import org.devridge.api.domain.community.entity.QCommunity;
+import org.devridge.api.domain.community.entity.QCommunityHashtag;
+import org.devridge.api.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -18,20 +25,30 @@ public class CommunityQuerydslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
     private QCommunity community = QCommunity.community;
+    private QCommunityHashtag communityHashtag = QCommunityHashtag.communityHashtag;
 
-    public Slice<CommunityListResponse> searchBySlice(Long lastId,Pageable pageable) {
-        List<CommunityListResponse> results = jpaQueryFactory
+
+    public Slice<CommunitySliceResponse> searchBySlice(Long lastId, Pageable pageable) {
+        List<Tuple> tuples = jpaQueryFactory
             .select(
-                Projections.constructor(
-                    CommunityListResponse.class,
-                    community.id,
-                    community.title,
-                    community.views,
-                    community.likeCount,
-                    community.comments.size().longValue()
-                )
+                community.id,
+                community.title,
+                community.views,
+                community.likeCount,
+                community.comments.size().longValue(),
+
+                community.member,
+
+                community.member.id,
+                community.member.nickname,
+                community.member.profileImageUrl,
+                community.member.introduction,
+
+                community.createdAt,
+                community.updatedAt
             )
             .from(community)
+            .leftJoin(community.member)
             .where(
                 ltId(lastId),
                 community.isDeleted.eq(false)
@@ -39,6 +56,68 @@ public class CommunityQuerydslRepository {
             .orderBy(community.id.desc())
             .limit(pageable.getPageSize() + 1)
             .fetch();
+
+        List<CommunitySliceResponse> results = new ArrayList<>();
+
+
+        for (Tuple tuple : tuples) {
+            Long communityId = tuple.get(community.id);
+            String title = tuple.get(community.title);
+            Long views = tuple.get(community.views);
+            Long likeCount = tuple.get(community.likeCount);
+            Long comments = tuple.get(community.comments.size().longValue());
+
+            Long memberId = tuple.get(community.member.id);
+            String nickname = tuple.get(community.member.nickname);
+            String profileImageUrl = tuple.get(community.member.profileImageUrl);
+            String introduction = tuple.get(community.member.introduction);
+
+            if (nickname == null) {
+                memberId = 0L;
+                nickname = "기본 닉네임";
+                profileImageUrl = "기본 프로필 이미지 URL";
+                introduction = "기본 소개";
+            }
+
+            Member member = tuple.get(community.member);
+
+            MemberInfoResponse memberInfoResponse = MemberInfoResponse.builder()
+                .memberId(memberId)
+                .nickName(nickname)
+                .profileImageUrl(profileImageUrl)
+                .introduction(introduction)
+                .build();
+
+            LocalDateTime createdAt = tuple.get(community.createdAt);
+            LocalDateTime updatedAt = tuple.get(community.updatedAt);
+
+            List<HashtagResponse> hashtags = jpaQueryFactory
+                .select(
+                    Projections.constructor(
+                        HashtagResponse.class,
+                        communityHashtag.hashtag.id,
+                        communityHashtag.hashtag.word,
+                        communityHashtag.hashtag.count
+                    )
+                )
+                .from(communityHashtag)
+                .where(communityHashtag.community.id.eq(tuple.get(community.id)))
+                .fetch();
+
+            results.add(
+                CommunitySliceResponse.builder()
+                    .id(communityId)
+                    .title(title)
+                    .views(views)
+                    .likeCount(likeCount)
+                    .comments(comments)
+                    .member(memberInfoResponse)
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .hashtags(hashtags)
+                    .build()
+            );
+        }
 
         return checkLastPage(pageable, results);
     }
@@ -52,7 +131,7 @@ public class CommunityQuerydslRepository {
         return community.id.lt(communityId);
     }
 
-    private Slice<CommunityListResponse> checkLastPage(Pageable pageable, List<CommunityListResponse> results) {
+    private Slice<CommunitySliceResponse> checkLastPage(Pageable pageable, List<CommunitySliceResponse> results) {
 
         boolean hasNext = false;
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -36,6 +36,7 @@ public class CommunityQuerydslRepository {
                 community.views,
                 community.likeCount,
                 community.comments.size().longValue(),
+                community.scraps.size().longValue(),
 
                 community.member,
 
@@ -66,7 +67,7 @@ public class CommunityQuerydslRepository {
             Long views = tuple.get(community.views);
             Long likeCount = tuple.get(community.likeCount);
             Long comments = tuple.get(community.comments.size().longValue());
-
+            Long scraps = tuple.get(community.scraps.size().longValue());
             Long memberId = tuple.get(community.member.id);
             String nickname = tuple.get(community.member.nickname);
             String profileImageUrl = tuple.get(community.member.profileImageUrl);
@@ -115,6 +116,7 @@ public class CommunityQuerydslRepository {
                     .createdAt(createdAt)
                     .updatedAt(updatedAt)
                     .hashtags(hashtags)
+                    .scraps(scraps)
                     .build()
             );
         }

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -1,11 +1,15 @@
 package org.devridge.api.domain.community.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import javax.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.devridge.api.domain.community.entity.LikeStatus;
-import org.devridge.api.domain.community.entity.QCommunityComment;
-import org.devridge.api.domain.community.entity.QCommunityCommentLikeDislike;
+import org.devridge.api.domain.community.dto.response.CommunityListResponse;
+import org.devridge.api.domain.community.entity.QCommunity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -13,29 +17,51 @@ import org.springframework.stereotype.Repository;
 public class CommunityQuerydslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
-    private QCommunityComment qCommunityComment = QCommunityComment.communityComment;
-    private QCommunityCommentLikeDislike qCommunityCommentLikeDislike = QCommunityCommentLikeDislike.communityCommentLikeDislike;
+    private QCommunity community = QCommunity.community;
 
-    @Transactional
-    public void updateLikeCountByCommentId(Long commentId) {
-        long likeCount = jpaQueryFactory
-            .select(qCommunityCommentLikeDislike.communityComment.id.count())
-            .from(qCommunityCommentLikeDislike)
-            .where(qCommunityCommentLikeDislike.communityComment.id.eq(commentId)
-                .and(qCommunityCommentLikeDislike.status.eq(LikeStatus.G)))
-            .fetchOne();
+    public Slice<CommunityListResponse> searchBySlice(Long lastId,Pageable pageable) {
+        List<CommunityListResponse> results = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    CommunityListResponse.class,
+                    community.id,
+                    community.title,
+                    community.views,
+                    community.likeCount,
+                    community.comments.size().longValue()
+                )
+            )
+            .from(community)
+            .where(
+                ltId(lastId),
+                community.isDeleted.eq(false)
+            )
+            .orderBy(community.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
 
-        long dislikeCount = jpaQueryFactory
-            .select(qCommunityCommentLikeDislike.communityComment.id.count())
-            .from(qCommunityCommentLikeDislike)
-            .where(qCommunityCommentLikeDislike.communityComment.id.eq(commentId)
-                .and(qCommunityCommentLikeDislike.status.eq(LikeStatus.B)))
-            .fetchOne();
+        return checkLastPage(pageable, results);
+    }
 
-        jpaQueryFactory
-            .update(qCommunityComment)
-            .set(qCommunityComment.likeCount, likeCount - dislikeCount)
-            .where(qCommunityComment.id.eq(commentId))
-            .execute();
+    // no-offset 방식 처리하는 메서드
+    private BooleanExpression ltId(Long communityId) {
+        if (communityId == null) {
+            return null;
+        }
+
+        return community.id.lt(communityId);
+    }
+
+    private Slice<CommunityListResponse> checkLastPage(Pageable pageable, List<CommunityListResponse> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -48,7 +48,7 @@ public class CommunityQuerydslRepository {
                         CommunitySliceResponse.class,
                         community.id,
                         community.title,
-                        community.views,
+                        community.viewCount,
                         community.likeCount,
                         community.comments.size().longValue(),
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityQuerydslRepository.java
@@ -31,6 +31,7 @@ public class CommunityQuerydslRepository {
             .selectFrom(community)
             .leftJoin(community.member)
             .leftJoin(community.hashtags, communityHashtag)
+            .leftJoin(communityHashtag.hashtag)
             .where(
                 ltId(lastId),
                 community.isDeleted.eq(false)

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/CommunityRepository.java
@@ -13,7 +13,7 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     @Modifying
     @Query(
         value = "UPDATE Community c " +
-                "SET c.views = c.views + 1 " +
+                "SET c.viewCount = c.viewCount + 1 " +
                 "WHERE c.id = :id")
     void updateView(@Param("id") Long id);
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectBulkRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectBulkRepository.java
@@ -1,0 +1,32 @@
+package org.devridge.api.domain.community.repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.community.entity.Project;
+import org.devridge.api.domain.skill.entity.Skill;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<Skill> skills, Project project){
+        String sql = "INSERT INTO project_skill (project_id, skill_id)"+
+            "VALUES (?, ?)";
+        Long projectId = project.getId();
+
+        jdbcTemplate.batchUpdate(sql,
+            skills,
+            skills.size(),
+            (PreparedStatement ps, Skill skill) -> {
+                ps.setLong(1, projectId);
+                ps.setLong(2, skill.getId());
+            });
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
@@ -4,17 +4,13 @@ import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.QProject;
+import org.devridge.api.domain.skill.entity.ProjectSkill;
 import org.devridge.api.domain.skill.entity.QProjectSkill;
-import org.devridge.api.domain.skill.entity.QSkill;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -24,66 +20,46 @@ public class ProjectQuerydslRepository {
     private final JPAQueryFactory jpaQueryFactory;
     private QProject project = QProject.project;
     private QProjectSkill projectSkill = QProjectSkill.projectSkill;
-    private QSkill skill = QSkill.skill1;
 
+    public List<ProjectSkill> findProjectSkillsInProjectIds(List<Long> projectIds) {
+        return jpaQueryFactory
+            .selectFrom(projectSkill)
+            .leftJoin(projectSkill.skill).fetchJoin()
+            .where(projectSkill.id.projectId.in(projectIds))
+            .fetch();
+    }
 
-    public Slice<ProjectListResponse> searchBySlice(Long lastId, Pageable pageable) {
-        List<ProjectListResponse> results = new ArrayList<>();
-
-        while (results.size() <= 10) {
-            List<ProjectListResponse> result = jpaQueryFactory
-                .selectFrom(project)
-                .leftJoin(project.member)
-                .leftJoin(project.projectSkills, projectSkill)
-                .leftJoin(projectSkill.skill, skill)
-                .where(
-                    ltId(lastId),
-                    project.isDeleted.eq(false)
-                )
-                .orderBy(project.id.desc())
-                .limit(pageable.getPageSize() + 1)
-                .transform(GroupBy.groupBy(project.id).
-                    list(Projections.constructor(
-                        ProjectListResponse.class,
-                        project.id,
-                        project.category,
-                        project.title,
-                        project.content,
-                        project.likes,
-                        project.dislikes,
-                        project.views,
-                        project.isRecruiting,
-                        GroupBy.list(skill.skill),
-                        project.meeting
-                    )));
-            results.addAll(result);
-        }
-
-
-
-        Pageable customPageable = PageRequest.of(0 , results.size() - 1, pageable.getSort());
-        return checkLastPage(customPageable, results);
+    public List<ProjectListResponse> searchByProject(Long lastId, Pageable pageable) {
+        return jpaQueryFactory
+            .selectFrom(project)
+            .leftJoin(project.member)
+            .where(
+                ltId(lastId),
+                project.isDeleted.eq(false)
+            )
+            .orderBy(project.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .transform(GroupBy.groupBy(project.id)
+                .list(Projections.fields(
+                    ProjectListResponse.class,
+                    project.id,
+                    project.category,
+                    project.title,
+                    project.content,
+                    project.likes,
+                    project.dislikes,
+                    project.views,
+                    project.isRecruiting,
+                    project.meeting
+                )));
     }
 
     // no-offset 방식 처리하는 메서드
-    private BooleanExpression ltId(Long communityId) {
-        if (communityId == null) {
+    private BooleanExpression ltId(Long projectId) {
+        if (projectId == null) {
             return null;
         }
 
-        return project.id.lt(communityId);
-    }
-
-    private Slice<ProjectListResponse> checkLastPage(Pageable pageable, List<ProjectListResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
+        return project.id.lt(projectId);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
@@ -4,12 +4,14 @@ import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.QProject;
 import org.devridge.api.domain.skill.entity.QProjectSkill;
 import org.devridge.api.domain.skill.entity.QSkill;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -26,34 +28,41 @@ public class ProjectQuerydslRepository {
 
 
     public Slice<ProjectListResponse> searchBySlice(Long lastId, Pageable pageable) {
-        List<ProjectListResponse> results = jpaQueryFactory
-            .selectFrom(project)
-            .leftJoin(project.member)
-            .leftJoin(project.projectSkills, projectSkill)
-            .leftJoin(projectSkill.skill, skill)
-            .where(
-                ltId(lastId),
-                project.isDeleted.eq(false)
-            )
-            .orderBy(project.id.desc())
-            .limit(pageable.getPageSize() + 1)
-            .transform(GroupBy.groupBy(project.id).
-                list(Projections.constructor(
-                    ProjectListResponse.class,
-                    project.id,
-                    project.category,
-                    project.title,
-                    project.content,
-                    project.likes,
-                    project.dislikes,
-                    project.views,
-                    project.isRecruiting,
-                    GroupBy.list(skill.skill),
-                    project.meeting
-            )));
+        List<ProjectListResponse> results = new ArrayList<>();
+
+        while (results.size() <= 10) {
+            List<ProjectListResponse> result = jpaQueryFactory
+                .selectFrom(project)
+                .leftJoin(project.member)
+                .leftJoin(project.projectSkills, projectSkill)
+                .leftJoin(projectSkill.skill, skill)
+                .where(
+                    ltId(lastId),
+                    project.isDeleted.eq(false)
+                )
+                .orderBy(project.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .transform(GroupBy.groupBy(project.id).
+                    list(Projections.constructor(
+                        ProjectListResponse.class,
+                        project.id,
+                        project.category,
+                        project.title,
+                        project.content,
+                        project.likes,
+                        project.dislikes,
+                        project.views,
+                        project.isRecruiting,
+                        GroupBy.list(skill.skill),
+                        project.meeting
+                    )));
+            results.addAll(result);
+        }
 
 
-        return checkLastPage(pageable, results);
+
+        Pageable customPageable = PageRequest.of(0 , results.size() - 1, pageable.getSort());
+        return checkLastPage(customPageable, results);
     }
 
     // no-offset 방식 처리하는 메서드

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.QProject;
 import org.devridge.api.domain.skill.entity.QProjectSkill;
+import org.devridge.api.domain.skill.entity.QSkill;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -21,6 +22,7 @@ public class ProjectQuerydslRepository {
     private final JPAQueryFactory jpaQueryFactory;
     private QProject project = QProject.project;
     private QProjectSkill projectSkill = QProjectSkill.projectSkill;
+    private QSkill skill = QSkill.skill1;
 
 
     public Slice<ProjectListResponse> searchBySlice(Long lastId, Pageable pageable) {
@@ -28,6 +30,7 @@ public class ProjectQuerydslRepository {
             .selectFrom(project)
             .leftJoin(project.member)
             .leftJoin(project.projectSkills, projectSkill)
+            .leftJoin(projectSkill.skill, skill)
             .where(
                 ltId(lastId),
                 project.isDeleted.eq(false)
@@ -45,7 +48,7 @@ public class ProjectQuerydslRepository {
                     project.dislikes,
                     project.views,
                     project.isRecruiting,
-                    GroupBy.list(Projections.constructor(String.class, projectSkill.skill.skill)),
+                    GroupBy.list(skill.skill),
                     project.meeting
             )));
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
@@ -1,0 +1,70 @@
+package org.devridge.api.domain.community.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.devridge.api.domain.community.dto.response.ProjectListResponse;
+import org.devridge.api.domain.community.entity.QProject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ProjectQuerydslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private QProject project = QProject.project;
+
+
+    public Slice<ProjectListResponse> searchBySlice(Long lastId, Pageable pageable) {
+        List<ProjectListResponse> results = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    ProjectListResponse.class,
+                    project.id,
+                    project.category,
+                    project.title,
+                    project.content,
+                    project.likes,
+                    project.dislikes,
+                    project.views
+                )
+            )
+            .from(project)
+            .where(
+                ltId(lastId),
+                project.isDeleted.eq(false)
+            )
+            .orderBy(project.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return checkLastPage(pageable, results);
+    }
+
+    // no-offset 방식 처리하는 메서드
+    private BooleanExpression ltId(Long communityId) {
+        if (communityId == null) {
+            return null;
+        }
+
+        return project.id.lt(communityId);
+    }
+
+    private Slice<ProjectListResponse> checkLastPage(Pageable pageable, List<ProjectListResponse> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/repository/ProjectQuerydslRepository.java
@@ -1,5 +1,6 @@
 package org.devridge.api.domain.community.repository;
 
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -7,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.QProject;
+import org.devridge.api.domain.skill.entity.QProjectSkill;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -18,12 +20,22 @@ public class ProjectQuerydslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
     private QProject project = QProject.project;
+    private QProjectSkill projectSkill = QProjectSkill.projectSkill;
 
 
     public Slice<ProjectListResponse> searchBySlice(Long lastId, Pageable pageable) {
         List<ProjectListResponse> results = jpaQueryFactory
-            .select(
-                Projections.constructor(
+            .selectFrom(project)
+            .leftJoin(project.member)
+            .leftJoin(project.projectSkills, projectSkill)
+            .where(
+                ltId(lastId),
+                project.isDeleted.eq(false)
+            )
+            .orderBy(project.id.desc())
+            .limit(pageable.getPageSize() + 1)
+            .transform(GroupBy.groupBy(project.id).
+                list(Projections.constructor(
                     ProjectListResponse.class,
                     project.id,
                     project.category,
@@ -31,17 +43,12 @@ public class ProjectQuerydslRepository {
                     project.content,
                     project.likes,
                     project.dislikes,
-                    project.views
-                )
-            )
-            .from(project)
-            .where(
-                ltId(lastId),
-                project.isDeleted.eq(false)
-            )
-            .orderBy(project.id.desc())
-            .limit(pageable.getPageSize() + 1)
-            .fetch();
+                    project.views,
+                    project.isRecruiting,
+                    GroupBy.list(Projections.constructor(String.class, projectSkill.skill.skill)),
+                    project.meeting
+            )));
+
 
         return checkLastPage(pageable, results);
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
@@ -38,11 +38,6 @@ public class CommunityCommentService {
         return communityCommentRepository.save(communityComment).getId();
     }
 
-//    public List<CommunityCommentResponse> getAllComment(Long communityId) {
-//        List<CommunityComment> communityComments = communityCommentRepository.findByCommunityId(communityId);
-//        return communityCommentMapper.toCommentResponses(communityComments);
-//    }
-
     public Slice<CommunityCommentResponse> getAllCommunityComment(Long communityId, Long lastId, Pageable pageable) {
         return communityCommentQuerydslReopsitory.searchBySlice(communityId, lastId, pageable);
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityCommentService.java
@@ -1,6 +1,5 @@
 package org.devridge.api.domain.community.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CommunityCommentRequest;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
@@ -8,12 +7,15 @@ import org.devridge.api.domain.community.entity.Community;
 import org.devridge.api.domain.community.entity.CommunityComment;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
 import org.devridge.api.domain.community.mapper.CommunityCommentMapper;
+import org.devridge.api.domain.community.repository.CommunityCommentQuerydslReopsitory;
 import org.devridge.api.domain.community.repository.CommunityCommentRepository;
 import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class CommunityCommentService {
     private final CommunityCommentMapper communityCommentMapper;
     private final CommunityRepository communityRepository;
     private final MemberRepository memberRepository;
+    private final CommunityCommentQuerydslReopsitory communityCommentQuerydslReopsitory;
 
     public Long createComment(Long communityId, CommunityCommentRequest commentRequest) {
         Community community = getCommunityById(communityId);
@@ -35,9 +38,13 @@ public class CommunityCommentService {
         return communityCommentRepository.save(communityComment).getId();
     }
 
-    public List<CommunityCommentResponse> getAllComment(Long communityId) {
-        List<CommunityComment> communityComments = communityCommentRepository.findByCommunityId(communityId);
-        return communityCommentMapper.toCommentResponses(communityComments);
+//    public List<CommunityCommentResponse> getAllComment(Long communityId) {
+//        List<CommunityComment> communityComments = communityCommentRepository.findByCommunityId(communityId);
+//        return communityCommentMapper.toCommentResponses(communityComments);
+//    }
+
+    public Slice<CommunityCommentResponse> getAllCommunityComment(Long communityId, Long lastId, Pageable pageable) {
+        return communityCommentQuerydslReopsitory.searchBySlice(communityId, lastId, pageable);
     }
 
     public void updateComment(Long communityId, Long commentId, CommunityCommentRequest commentRequest) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -92,11 +92,6 @@ public class CommunityService {
         }
     }
 
-//    public List<CommunityListResponse> getAllCommunity() {
-//        List<Community> communities = communityRepository.findAll();
-//        return communityMapper.toCommunityListResponses(communities);
-//    }
-
     public Slice<CommunitySliceResponse> getAllCommunity(Long lastId, Pageable pageable) {
         List<CommunitySliceResponse> communitySliceResponses = communityQuerydslRepository.searchByCommunity(lastId, pageable);
         List<Long> communityIds = toCommunityIds(communitySliceResponses);

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.community.dto.request.CreateCommunityRequest;
 import org.devridge.api.domain.community.dto.response.CommunityDetailResponse;
-import org.devridge.api.domain.community.dto.response.CommunityListResponse;
+import org.devridge.api.domain.community.dto.response.CommunitySliceResponse;
 import org.devridge.api.domain.community.entity.Community;
 import org.devridge.api.domain.community.entity.CommunityHashtag;
 import org.devridge.api.domain.community.entity.Hashtag;
@@ -91,7 +91,7 @@ public class CommunityService {
 //        return communityMapper.toCommunityListResponses(communities);
 //    }
 
-    public Slice<CommunityListResponse> getAllCommunity(Long lastId, Pageable pageable) {
+    public Slice<CommunitySliceResponse> getAllCommunity(Long lastId, Pageable pageable) {
         return communityQuerydslRepository.searchBySlice(lastId, pageable);
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/CommunityService.java
@@ -14,6 +14,7 @@ import org.devridge.api.domain.community.entity.id.CommunityHashtagId;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
 import org.devridge.api.domain.community.mapper.CommunityMapper;
 import org.devridge.api.domain.community.repository.CommunityHashtagRepository;
+import org.devridge.api.domain.community.repository.CommunityQuerydslRepository;
 import org.devridge.api.domain.community.repository.CommunityRepository;
 import org.devridge.api.domain.community.repository.HashtagRepository;
 import org.devridge.api.domain.member.entity.Member;
@@ -21,6 +22,8 @@ import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.domain.s3.service.S3Service;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +37,7 @@ public class CommunityService {
     private final CommunityHashtagRepository communityHashtagRepository;
     private final HashtagRepository hashtagRepository;
     private final S3Service s3Service;
+    private final CommunityQuerydslRepository communityQuerydslRepository;
 
     public Long createCommunity(CreateCommunityRequest communityRequest) {
         Long accessMemberId = SecurityContextHolderUtil.getMemberId();
@@ -82,9 +86,13 @@ public class CommunityService {
         }
     }
 
-    public List<CommunityListResponse> getAllCommunity() {
-        List<Community> communities = communityRepository.findAll();
-        return communityMapper.toCommunityListResponses(communities);
+//    public List<CommunityListResponse> getAllCommunity() {
+//        List<Community> communities = communityRepository.findAll();
+//        return communityMapper.toCommunityListResponses(communities);
+//    }
+
+    public Slice<CommunityListResponse> getAllCommunity(Long lastId, Pageable pageable) {
+        return communityQuerydslRepository.searchBySlice(lastId, pageable);
     }
 
     private Community getCommunityById(Long communityId) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -54,10 +54,10 @@ public class ProjectService {
     public ProjectDetailResponse getProjectDetail(Long projectId) {
         Project project = getProjectById(projectId);
 
-        List<ProjectSkill> temp = project.getProjectSkills();
+        List<ProjectSkill> projectSkills = project.getProjectSkills();
         List<String> skills = new ArrayList<>();
-        for (ProjectSkill t : temp) {
-            skills.add(t.getSkill().getSkill());
+        for (ProjectSkill projectSkill : projectSkills) {
+            skills.add(projectSkill.getSkill().getSkill());
         }
 
         projectRepository.updateView(projectId);

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -64,11 +64,6 @@ public class ProjectService {
         return projectMapper.toProjectDetailResponse(project, skills);
     }
 
-//    public List<ProjectListResponse> getAllProject() {
-//        List<Project> project = projectRepository.findAll();
-//        return projectMapper.toProjectListResponses(project);
-//    }
-
     public Slice<ProjectListResponse> getAllProject(Long lastId, Pageable pageable) {
         return projectQuerydslRepository.searchBySlice(lastId, pageable);
     }

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -92,9 +92,9 @@ public class ProjectService {
             project.updateProject(
                 request.getTitle(),
                 request.getContent(),
-                request.getCategory().getValue(),
+                request.getCategory(),
                 images.substring(1, images.length() - 1),
-                request.getMeeting().toString(),
+                request.getMeeting(),
                 request.getIsRecruiting()
             );
 
@@ -104,9 +104,9 @@ public class ProjectService {
         project.updateProject(
             request.getTitle(),
             request.getContent(),
-            request.getCategory().getValue(),
+            request.getCategory(),
             null,
-            request.getMeeting().toString(),
+            request.getMeeting(),
             request.getIsRecruiting()
         );
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -10,6 +10,7 @@ import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
 import org.devridge.api.domain.community.mapper.ProjectMapper;
+import org.devridge.api.domain.community.repository.ProjectBulkRepository;
 import org.devridge.api.domain.community.repository.ProjectQuerydslRepository;
 import org.devridge.api.domain.community.repository.ProjectRepository;
 import org.devridge.api.domain.member.entity.Member;
@@ -37,6 +38,7 @@ public class ProjectService {
     private final ProjectQuerydslRepository projectQuerydslRepository;
     private final ProjectSkillRepository projectSkillRepository;
     private final SkillRepository skillRepository;
+    private final ProjectBulkRepository projectBulkRepository;
 
     @Transactional
     public Long createProject(ProjectRequest request) {
@@ -131,14 +133,7 @@ public class ProjectService {
         List<Skill> skills = skillRepository.findSkillsByIds(skillIds);
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new DataNotFoundException());
 
-        for (Skill skill : skills) {
-            projectSkillRepository.save(
-                ProjectSkill.builder()
-                    .skill(skill)
-                    .project(project)
-                    .build()
-            );
-        }
+        projectBulkRepository.saveAll(skills, project);
     }
 
     private Project getProjectById(Long projectId) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -83,6 +83,9 @@ public class ProjectService {
             throw new MyCommunityForbiddenException(403, "내가 작성하지 않은 글은 수정할 수 없습니다.");
         }
 
+        projectSkillRepository.deleteByProjectId(projectId);
+
+
         if (request.getImages() != null && !request.getImages().isEmpty()) {
             String images = request.getImages().toString();
 
@@ -90,11 +93,25 @@ public class ProjectService {
                 request.getTitle(),
                 request.getContent(),
                 request.getCategory().getValue(),
-                images.substring(1, images.length() - 1)
+                images.substring(1, images.length() - 1),
+                request.getMeeting().toString(),
+                request.getIsRecruiting()
             );
+
+            createProjectSkill(request.getSkillIds(), projectId);
             return;
         }
-        project.updateProject(request.getTitle(), request.getContent(), request.getCategory().getValue(), null);
+        project.updateProject(
+            request.getTitle(),
+            request.getContent(),
+            request.getCategory().getValue(),
+            null,
+            request.getMeeting().toString(),
+            request.getIsRecruiting()
+        );
+
+        createProjectSkill(request.getSkillIds(), projectId);
+
     }
 
     @Transactional

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -1,5 +1,6 @@
 package org.devridge.api.domain.community.service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,10 @@ import org.devridge.api.domain.community.repository.ProjectRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.domain.s3.service.S3Service;
+import org.devridge.api.domain.skill.entity.ProjectSkill;
+import org.devridge.api.domain.skill.entity.Skill;
+import org.devridge.api.domain.skill.repository.ProjectSkillRepository;
+import org.devridge.api.domain.skill.repository.SkillRepository;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
 import org.springframework.data.domain.Pageable;
@@ -48,8 +53,15 @@ public class ProjectService {
     @Transactional
     public ProjectDetailResponse getProjectDetail(Long projectId) {
         Project project = getProjectById(projectId);
+
+        List<ProjectSkill> temp = project.getProjectSkills();
+        List<String> skills = new ArrayList<>();
+        for (ProjectSkill t : temp) {
+            skills.add(t.getSkill().getSkill());
+        }
+
         projectRepository.updateView(projectId);
-        return projectMapper.toProjectDetailResponse(project);
+        return projectMapper.toProjectDetailResponse(project, skills);
     }
 
 //    public List<ProjectListResponse> getAllProject() {

--- a/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/service/ProjectService.java
@@ -9,12 +9,15 @@ import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
 import org.devridge.api.domain.community.mapper.ProjectMapper;
+import org.devridge.api.domain.community.repository.ProjectQuerydslRepository;
 import org.devridge.api.domain.community.repository.ProjectRepository;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.member.repository.MemberRepository;
 import org.devridge.api.domain.s3.service.S3Service;
 import org.devridge.api.exception.common.DataNotFoundException;
 import org.devridge.api.util.SecurityContextHolderUtil;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,7 @@ public class ProjectService {
     private final ProjectMapper projectMapper;
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
+    private final ProjectQuerydslRepository projectQuerydslRepository;
 
     public Long createProject(ProjectRequest request) {
         Long accessMemberId = SecurityContextHolderUtil.getMemberId();
@@ -42,9 +46,13 @@ public class ProjectService {
         return projectMapper.toProjectDetailResponse(project);
     }
 
-    public List<ProjectListResponse> getAllProject() {
-        List<Project> project = projectRepository.findAll();
-        return projectMapper.toProjectListResponses(project);
+//    public List<ProjectListResponse> getAllProject() {
+//        List<Project> project = projectRepository.findAll();
+//        return projectMapper.toProjectListResponses(project);
+//    }
+
+    public Slice<ProjectListResponse> getAllProject(Long lastId, Pageable pageable) {
+        return projectQuerydslRepository.searchBySlice(lastId, pageable);
     }
 
     @Transactional

--- a/api-module/src/main/java/org/devridge/api/domain/community/validator/EnumValidator.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/validator/EnumValidator.java
@@ -1,0 +1,29 @@
+package org.devridge.api.domain.community.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidateEnum, String> {
+
+    private ValidateEnum validateEnum;
+
+    @Override
+    public void initialize(ValidateEnum constraintAnnotation) {
+        this.validateEnum = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        Object[] enumValues = this.validateEnum.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())
+                    || (this.validateEnum.ignoreCase() && value.equalsIgnoreCase(enumValue.toString()))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/community/validator/ValidateEnum.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/validator/ValidateEnum.java
@@ -1,0 +1,23 @@
+package org.devridge.api.domain.community.validator;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = {EnumValidator.class})
+public @interface ValidateEnum {
+
+    String message() default "Enum에 없는 값입니다.";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default { };
+    Class<? extends Enum<?>> enumClass();
+    boolean ignoreCase() default false;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/entity/ProjectSkill.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/entity/ProjectSkill.java
@@ -29,7 +29,7 @@ public class ProjectSkill extends BaseTimeEntity {
     @JoinColumn(name = "project_id")
     private Project project;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("skillId")
     @JoinColumn(name = "skill_id")
     private Skill skill;

--- a/api-module/src/main/java/org/devridge/api/domain/skill/entity/ProjectSkill.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/entity/ProjectSkill.java
@@ -1,0 +1,43 @@
+package org.devridge.api.domain.skill.entity;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.devridge.api.domain.community.entity.Project;
+import org.devridge.api.domain.skill.entity.key.ProjectSkillId;
+import org.devridge.common.entity.BaseTimeEntity;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+public class ProjectSkill extends BaseTimeEntity {
+
+    @EmbeddedId
+    private ProjectSkillId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("projectId")
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @MapsId("skillId")
+    @JoinColumn(name = "skill_id")
+    private Skill skill;
+
+    @Builder
+    public ProjectSkill(Project project, Skill skill) {
+        this.id = new ProjectSkillId(project.getId(), skill.getId());
+        this.project = project;
+        this.skill = skill;
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/entity/Skill.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/entity/Skill.java
@@ -1,5 +1,12 @@
 package org.devridge.api.domain.skill.entity;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,12 +14,6 @@ import org.devridge.common.entity.BaseEntity;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -27,6 +28,9 @@ public class Skill extends BaseEntity {
 
     @OneToMany(mappedBy = "skill")
     private Set<MemberSkill> memberSkills = new HashSet<>();
+
+    @OneToMany(mappedBy = "skill")
+    private List<ProjectSkill> projectSkills = new ArrayList<>();
 
     @Builder
     public Skill(String skill) {

--- a/api-module/src/main/java/org/devridge/api/domain/skill/entity/key/ProjectSkillId.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/entity/key/ProjectSkillId.java
@@ -1,0 +1,17 @@
+package org.devridge.api.domain.skill.entity.key;
+
+import java.io.Serializable;
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ProjectSkillId implements Serializable {
+
+    private Long projectId;
+    private Long skillId;
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/ProjectSkillRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/ProjectSkillRepository.java
@@ -1,0 +1,9 @@
+package org.devridge.api.domain.skill.repository;
+
+import org.devridge.api.domain.skill.entity.ProjectSkill;
+import org.devridge.api.domain.skill.entity.key.ProjectSkillId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectSkillRepository extends JpaRepository<ProjectSkill, ProjectSkillId> {
+
+}

--- a/api-module/src/main/java/org/devridge/api/domain/skill/repository/ProjectSkillRepository.java
+++ b/api-module/src/main/java/org/devridge/api/domain/skill/repository/ProjectSkillRepository.java
@@ -3,7 +3,16 @@ package org.devridge.api.domain.skill.repository;
 import org.devridge.api.domain.skill.entity.ProjectSkill;
 import org.devridge.api.domain.skill.entity.key.ProjectSkillId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectSkillRepository extends JpaRepository<ProjectSkill, ProjectSkillId> {
 
+    @Modifying
+    @Query(
+        value = "DELETE FROM ProjectSkill p " +
+                "WHERE p.id.projectId = :id"
+    )
+    void deleteByProjectId(@Param("id") Long id);
 }


### PR DESCRIPTION
## Description ✍️
* 자유게시판 전체 목록 무한스크롤을 구현하였습니다.
* 자유게시글 댓글 목록 무한스크롤을 구현하였습니다.
* 프로젝트 전체 목록 무한스크롤을 구현하였습니다.
* 화면 디자인에 맞게 api를 수정하였습니다.

## 테스트 시 유의사항 ⚠️
* postman에서 테스트 가능합니다.

## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?