### PR TITLE
채팅 메세지 전송 API에서 access token 정보를 받아오지 못하는 문제를 수정합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatService.java
+++ b/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatService.java
@@ -170,8 +170,8 @@ public class CoffeeChatService {
         throw new BadRequestException();
     }
 
-    public GetAllChatMessage createChatMessage(CreateChatMessageRequest request, Long roomId, Long memberId) {
-        Member member = this.getMember(memberId);
+    public GetAllChatMessage createChatMessage(CreateChatMessageRequest request, Long roomId, String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(DataNotFoundException::new);
         ChatRoom chatRoom = this.getChatRoom(roomId);
         ChatMessage chatMessage = coffeeChatMapper.toChatMessage(request, member, chatRoom);
 
@@ -188,10 +188,6 @@ public class CoffeeChatService {
     }
 
     private Member getMember(Long memberId) {
-        // TODO: 채팅 테스트용 임시 아이디 생성, 추후 실제 Frontend와 연결 시 수정
-        if (memberId == null) {
-            memberId = 1L;
-        }
         return memberRepository.findById(memberId).orElseThrow(DataNotFoundException::new);
     }
 

--- a/api-module/src/main/java/org/devridge/api/common/handler/StompHandler.java
+++ b/api-module/src/main/java/org/devridge/api/common/handler/StompHandler.java
@@ -9,12 +9,15 @@ import lombok.RequiredArgsConstructor;
 import org.devridge.api.domain.member.exception.AccessTokenInvalidException;
 import org.devridge.api.common.util.AccessTokenUtil;
 
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 @RequiredArgsConstructor
 @Component
@@ -25,12 +28,34 @@ public class StompHandler implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
         if (accessor.getCommand() == StompCommand.CONNECT) {
-            if (!this.validateAccessToken(accessor.getFirstNativeHeader("Authorization"))) {
+            String accessToken = accessor.getFirstNativeHeader("Authorization");
+            if (!this.validateAccessToken(accessToken)) {
                 throw new AccessTokenInvalidException(401, "access token이 필요합니다.");
             }
+
+            String email = this.getEmail(accessToken);
+            accessor.addNativeHeader("senderEmail", email);
         }
 
         return message;
+    }
+
+    private String getEmail(String accessToken) {
+        String bearerToken = accessToken.trim();
+
+        if (!bearerToken.trim().isEmpty() && bearerToken.startsWith("Bearer ")) {
+            accessToken = bearerToken.substring(7);
+
+            try {
+                Claims claims = AccessTokenUtil.getClaimsFromAccessToken(accessToken);
+                String email = claims.get("memberEmail", String.class);
+                return email;
+            } catch (ExpiredJwtException | MalformedJwtException e) {
+                throw new AccessTokenInvalidException(401, "");
+            }
+        }
+
+        return null;
     }
 
     private boolean validateAccessToken(String accessToken) {
@@ -52,5 +77,16 @@ public class StompHandler implements ChannelInterceptor {
         }
 
         return false;
+    }
+
+    @EventListener(SessionConnectEvent.class)
+    public void onApplicationEvent(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String accessToken = accessor.getFirstNativeHeader("Authorization");
+        if (this.validateAccessToken(accessToken)) {
+            String email = this.getEmail(accessToken);
+            // Set the memberId as a session attribute
+            accessor.getSessionAttributes().put("senderEmail", email);
+        }
     }
 }

--- a/api-module/src/main/java/org/devridge/api/common/handler/StompHandler.java
+++ b/api-module/src/main/java/org/devridge/api/common/handler/StompHandler.java
@@ -51,7 +51,7 @@ public class StompHandler implements ChannelInterceptor {
                 String email = claims.get("memberEmail", String.class);
                 return email;
             } catch (ExpiredJwtException | MalformedJwtException e) {
-                throw new AccessTokenInvalidException(401, "");
+                throw new AccessTokenInvalidException(401, "해당 토큰이 만료되었거나 올바른 형태가 아닙니다.");
             }
         }
 
@@ -85,7 +85,6 @@ public class StompHandler implements ChannelInterceptor {
         String accessToken = accessor.getFirstNativeHeader("Authorization");
         if (this.validateAccessToken(accessToken)) {
             String email = this.getEmail(accessToken);
-            // Set the memberId as a session attribute
             accessor.getSessionAttributes().put("senderEmail", email);
         }
     }

--- a/api-module/src/main/java/org/devridge/api/infrastructure/member/MemberRepository.java
+++ b/api-module/src/main/java/org/devridge/api/infrastructure/member/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndProvider(String email, String provider);
 
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/coffeechat/ChatStompController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/coffeechat/ChatStompController.java
@@ -7,13 +7,18 @@ import org.devridge.api.domain.coffeechat.dto.response.GetAllChatMessage;
 import org.devridge.api.application.coffeechat.CoffeeChatService;
 
 import org.devridge.api.domain.member.entity.Member;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+
+import static org.devridge.api.common.util.SecurityContextHolderUtil.getMemberId;
 
 @RequiredArgsConstructor
 @Controller
@@ -32,9 +37,10 @@ public class ChatStompController {
     public void createChatMessage(
         @DestinationVariable Long roomId,
         @Payload CreateChatMessageRequest request,
-        @AuthenticationPrincipal Member member
+        SimpMessageHeaderAccessor accessor
     ) {
-        GetAllChatMessage message = coffeeChatService.createChatMessage(request, roomId, member.getId());
+        String email = (String) accessor.getSessionAttributes().get("senderEmail");
+        GetAllChatMessage message = coffeeChatService.createChatMessage(request, roomId, email);
         template.convertAndSend("/api/sub/" + roomId, message);
     }
 }


### PR DESCRIPTION
## Description ✍️
* 채팅 메세지 전송 API에서 access token 정보를 받아오지 못하는 문제를 수정합니다.

## Screen Shot 📷
채팅 메세지 보낼 때 이제 보낸 사람 아이디로 잘 와요 ㅠ_ㅠ
<img width="1071" alt="스크린샷 2024-03-30 오후 3 47 15" src="https://github.com/devridge-team-project/devridge-server/assets/96467030/d2815064-254b-437a-a920-2438b78e7f9f">

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
