### PR TITLE
무한스크롤 반환 형식을 요청에 맞게 수정합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/community/freeboard/CommunityCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/freeboard/CommunityCommentService.java
@@ -1,22 +1,20 @@
 package org.devridge.api.application.community.freeboard;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-
+import org.devridge.api.common.exception.common.DataNotFoundException;
+import org.devridge.api.common.util.SecurityContextHolderUtil;
 import org.devridge.api.domain.community.dto.request.CommunityCommentRequest;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
 import org.devridge.api.domain.community.entity.Community;
 import org.devridge.api.domain.community.entity.CommunityComment;
 import org.devridge.api.domain.community.exception.MyCommunityForbiddenException;
+import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.infrastructure.community.freeboard.CommunityCommentQuerydslReopsitory;
 import org.devridge.api.infrastructure.community.freeboard.CommunityCommentRepository;
 import org.devridge.api.infrastructure.community.freeboard.CommunityRepository;
-import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.infrastructure.member.MemberRepository;
-import org.devridge.api.common.exception.common.DataNotFoundException;
-import org.devridge.api.common.util.SecurityContextHolderUtil;
-
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -39,7 +37,7 @@ public class CommunityCommentService {
         return communityCommentRepository.save(communityComment).getId();
     }
 
-    public Slice<CommunityCommentResponse> getAllCommunityComment(Long communityId, Long lastId, Pageable pageable) {
+    public List<CommunityCommentResponse> getAllCommunityComment(Long communityId, Long lastId, Pageable pageable) {
         return communityCommentQuerydslReopsitory.searchBySlice(communityId, lastId, pageable);
     }
 

--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectCommentService.java
@@ -15,8 +15,6 @@ import org.devridge.api.infrastructure.community.project.ProjectCommentRepositor
 import org.devridge.api.infrastructure.community.project.ProjectRepository;
 import org.devridge.api.infrastructure.member.MemberRepository;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -39,23 +37,8 @@ public class ProjectCommentService {
         return projectCommentRepository.save(projectComment).getId();
     }
 
-    public Slice<ProjectCommentResponse> getAllProjectComment(Long projectId, Long lastId, Pageable pageable) {
-        List<ProjectCommentResponse> results =
-                projectCommentQuerydslRepository.searchBySlice(projectId, lastId, pageable);
-        return checkLastPage(pageable, results);
-    }
-
-    private Slice<ProjectCommentResponse> checkLastPage(Pageable pageable, List<ProjectCommentResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
+    public List<ProjectCommentResponse> getAllProjectComment(Long projectId, Long lastId, Pageable pageable) {
+        return projectCommentQuerydslRepository.searchBySlice(projectId, lastId, pageable);
     }
 
     public void updateComment(Long projectId, Long commentId, ProjectCommentRequest commentRequest) {

--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectService.java
@@ -27,8 +27,6 @@ import org.devridge.api.infrastructure.member.MemberRepository;
 import org.devridge.api.infrastructure.skill.ProjectSkillRepository;
 import org.devridge.api.infrastructure.skill.SkillRepository;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,12 +69,11 @@ public class ProjectService {
         return projectMapper.toProjectDetailResponse(project, skills);
     }
 
-    public Slice<ProjectListResponse> getAllProject(Long lastId, Pageable pageable) {
+    public List<ProjectListResponse> getAllProject(Long lastId, Pageable pageable) {
         List<ProjectListResponse> projectListResponses = projectQuerydslRepository.searchByProject(lastId, pageable);
         List<Long> projectIds = toProjectIds(projectListResponses);
         List<ProjectSkill> projectSkills = projectQuerydslRepository.findProjectSkillsInProjectIds(projectIds);
-        List<ProjectListResponse> groupedByProjectListResponses = groupByProjectId(projectSkills, projectListResponses);
-        return checkLastPage(pageable, groupedByProjectListResponses);
+        return groupByProjectId(projectSkills, projectListResponses);
     }
 
     private List<ProjectListResponse> groupByProjectId(List<ProjectSkill> projectSkills, List<ProjectListResponse> projectListResponses) {
@@ -107,18 +104,6 @@ public class ProjectService {
         }
 
         return projectListResponses;
-    }
-    private Slice<ProjectListResponse> checkLastPage(Pageable pageable, List<ProjectListResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
     }
 
     private List<Long> toProjectIds(List<ProjectListResponse> projectListResponses) {

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyCommentService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyCommentService.java
@@ -15,8 +15,6 @@ import org.devridge.api.infrastructure.community.study.StudyCommentRepository;
 import org.devridge.api.infrastructure.community.study.StudyRepository;
 import org.devridge.api.infrastructure.member.MemberRepository;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -39,23 +37,8 @@ public class StudyCommentService {
         return studyCommentRepository.save(studyComment).getId();
     }
 
-    public Slice<StudyCommentResponse> getAllStudyComment(Long studyId, Long lastId, Pageable pageable) {
-        List<StudyCommentResponse> results =
-            studyCommentQuerydslRepository.searchBySlice(studyId, lastId, pageable);
-        return checkLastPage(pageable, results);
-    }
-
-    private Slice<StudyCommentResponse> checkLastPage(Pageable pageable, List<StudyCommentResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
+    public List<StudyCommentResponse> getAllStudyComment(Long studyId, Long lastId, Pageable pageable) {
+        return studyCommentQuerydslRepository.searchBySlice(studyId, lastId, pageable);
     }
 
     public void updateComment(Long studyId, Long commentId, StudyCommentRequest commentRequest) {

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyService.java
@@ -16,8 +16,6 @@ import org.devridge.api.infrastructure.community.study.StudyQuerydslRepository;
 import org.devridge.api.infrastructure.community.study.StudyRepository;
 import org.devridge.api.infrastructure.member.MemberRepository;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,23 +44,10 @@ public class StudyService {
         return studyMapper.toStudyDetailResponse(study);
     }
 
-    public Slice<StudyListResponse> getAllStudy(Long lastId, Pageable pageable) {
+    public List<StudyListResponse> getAllStudy(Long lastId, Pageable pageable) {
         List<Study> studies = studyQuerydslRepository.searchByStudy(lastId, pageable);
-        List<StudyListResponse> studyListResponses = studyMapper.toStudyListResponses(studies);
-        return checkLastPage(pageable, studyListResponses);
-    }
+        return studyMapper.toStudyListResponses(studies);
 
-    private Slice<StudyListResponse> checkLastPage(Pageable pageable, List<StudyListResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
     }
 
     @Transactional

--- a/api-module/src/main/java/org/devridge/api/infrastructure/community/freeboard/CommunityCommentQuerydslReopsitory.java
+++ b/api-module/src/main/java/org/devridge/api/infrastructure/community/freeboard/CommunityCommentQuerydslReopsitory.java
@@ -11,8 +11,6 @@ import org.devridge.api.common.dto.UserInformation;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
 import org.devridge.api.domain.community.entity.QCommunityComment;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,8 +20,8 @@ public class CommunityCommentQuerydslReopsitory {
     private final JPAQueryFactory jpaQueryFactory;
     private QCommunityComment comment = QCommunityComment.communityComment;
 
-    public Slice<CommunityCommentResponse> searchBySlice(Long communityId, Long lastId, Pageable pageable) {
-        List<CommunityCommentResponse> results = jpaQueryFactory
+    public List<CommunityCommentResponse> searchBySlice(Long communityId, Long lastId, Pageable pageable) {
+        return jpaQueryFactory
             .selectFrom(comment)
             .leftJoin(comment.member)
             .where(
@@ -64,7 +62,6 @@ public class CommunityCommentQuerydslReopsitory {
                     )
                 )
             ));
-        return checkLastPage(pageable, results);
     }
 
     // no-offset 방식 처리하는 메서드
@@ -75,18 +72,4 @@ public class CommunityCommentQuerydslReopsitory {
 
         return comment.id.lt(communityId);
     }
-
-    private Slice<CommunityCommentResponse> checkLastPage(Pageable pageable, List<CommunityCommentResponse> results) {
-
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
-        if (results.size() > pageable.getPageSize()) {
-            hasNext = true;
-            results.remove(pageable.getPageSize());
-        }
-
-        return new SliceImpl<>(results, pageable, hasNext);
-    }
-
 }

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/freeboard/CommunityCommentController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/freeboard/CommunityCommentController.java
@@ -1,13 +1,13 @@
 package org.devridge.api.presentation.controller.community.freeboard;
 
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.application.community.freeboard.CommunityCommentService;
 import org.devridge.api.domain.community.dto.request.CommunityCommentRequest;
 import org.devridge.api.domain.community.dto.response.CommunityCommentResponse;
-import org.devridge.api.application.community.freeboard.CommunityCommentService;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,12 +37,12 @@ public class CommunityCommentController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<CommunityCommentResponse>> getAllComments(
+    public ResponseEntity<List<CommunityCommentResponse>> getAllComments(
         @PathVariable Long communityId,
         @RequestParam(name = "lastId", required = false) Long lastId,
-        @PageableDefault( ) Pageable pageable
+        @PageableDefault Pageable pageable
     ) {
-        Slice<CommunityCommentResponse> commentResponses = communityCommentService.getAllCommunityComment(communityId, lastId, pageable);
+        List<CommunityCommentResponse> commentResponses = communityCommentService.getAllCommunityComment(communityId, lastId, pageable);
         return ResponseEntity.ok().body(commentResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/freeboard/CommunityController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/freeboard/CommunityController.java
@@ -1,14 +1,14 @@
 package org.devridge.api.presentation.controller.community.freeboard;
 
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.application.community.freeboard.CommunityService;
 import org.devridge.api.domain.community.dto.request.CreateCommunityRequest;
 import org.devridge.api.domain.community.dto.response.CommunityDetailResponse;
 import org.devridge.api.domain.community.dto.response.CommunitySliceResponse;
-import org.devridge.api.application.community.freeboard.CommunityService;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -56,11 +56,11 @@ public class CommunityController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<CommunitySliceResponse>> getAllCommunity(
+    public ResponseEntity<List<CommunitySliceResponse>> getAllCommunity(
         @RequestParam(name = "lastId", required = false) Long lastId,
-        @PageableDefault( ) Pageable pageable
+        @PageableDefault Pageable pageable
     ) {
-        Slice<CommunitySliceResponse> communitySliceResponses = communityService.getAllCommunity(lastId, pageable);
+        List<CommunitySliceResponse> communitySliceResponses = communityService.getAllCommunity(lastId, pageable);
         return ResponseEntity.ok().body(communitySliceResponses);
     }
 }

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/project/ProjectCommentController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/project/ProjectCommentController.java
@@ -1,13 +1,13 @@
 package org.devridge.api.presentation.controller.community.project;
 
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.application.community.project.ProjectCommentService;
 import org.devridge.api.domain.community.dto.request.ProjectCommentRequest;
 import org.devridge.api.domain.community.dto.response.ProjectCommentResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,12 +36,12 @@ public class ProjectCommentController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<ProjectCommentResponse>> getAllComments(
+    public ResponseEntity<List<ProjectCommentResponse>> getAllComments(
         @PathVariable Long projectId,
         @RequestParam(name = "lastId", required = false) Long lastId,
         Pageable pageable
     ) {
-        Slice<ProjectCommentResponse> commentResponses = projectCommentService.getAllProjectComment(projectId, lastId, pageable);
+        List<ProjectCommentResponse> commentResponses = projectCommentService.getAllProjectComment(projectId, lastId, pageable);
         return ResponseEntity.ok().body(commentResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/project/ProjectController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/project/ProjectController.java
@@ -1,14 +1,14 @@
 package org.devridge.api.presentation.controller.community.project;
 
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.devridge.api.application.community.project.ProjectService;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
 import org.devridge.api.domain.community.dto.response.ProjectListResponse;
-import org.devridge.api.application.community.project.ProjectService;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,11 +40,11 @@ public class ProjectController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<ProjectListResponse>> getAllProject(
+    public ResponseEntity<List<ProjectListResponse>> getAllProject(
         @RequestParam(name = "lastId", required = false) Long lastId,
         Pageable pageable
     ) {
-        Slice<ProjectListResponse> projectListResponses = projectService.getAllProject(lastId, pageable);
+        List<ProjectListResponse> projectListResponses = projectService.getAllProject(lastId, pageable);
         return ResponseEntity.ok().body(projectListResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/study/StudyCommentController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/study/StudyCommentController.java
@@ -1,13 +1,13 @@
 package org.devridge.api.presentation.controller.community.study;
 
 import java.net.URI;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.application.community.study.StudyCommentService;
 import org.devridge.api.domain.community.dto.request.StudyCommentRequest;
 import org.devridge.api.domain.community.dto.response.StudyCommentResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,12 +36,12 @@ public class StudyCommentController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<StudyCommentResponse>> getAllComments(
+    public ResponseEntity<List<StudyCommentResponse>> getAllComments(
         @PathVariable Long studyId,
         @RequestParam(name = "lastId", required = false) Long lastId,
         Pageable pageable
     ) {
-        Slice<StudyCommentResponse> commentResponses = studyCommentService.getAllStudyComment(studyId, lastId, pageable);
+        List<StudyCommentResponse> commentResponses = studyCommentService.getAllStudyComment(studyId, lastId, pageable);
         return ResponseEntity.ok().body(commentResponses);
     }
 

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/community/study/StudyController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/community/study/StudyController.java
@@ -1,13 +1,13 @@
 package org.devridge.api.presentation.controller.community.study;
 
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.devridge.api.application.community.study.StudyService;
 import org.devridge.api.domain.community.dto.request.StudyRequest;
 import org.devridge.api.domain.community.dto.response.StudyDetailResponse;
 import org.devridge.api.domain.community.dto.response.StudyListResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,11 +39,11 @@ public class StudyController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<StudyListResponse>> getAllStudy(
+    public ResponseEntity<List<StudyListResponse>> getAllStudy(
         @RequestParam(name = "lastId", required = false) Long lastId,
         Pageable pageable
     ) {
-        Slice<StudyListResponse> studyListResponses = studyService.getAllStudy(lastId, pageable);
+        List<StudyListResponse> studyListResponses = studyService.getAllStudy(lastId, pageable);
         return ResponseEntity.ok().body(studyListResponses);
     }
 


### PR DESCRIPTION
## Description ✍️
* 자유게시글, 프로젝트, 스터디 각각 전체 목록 및 댓글의 무한스크롤 반환 형식을 데이터만 보내도록 수정하였습니다.

## 테스트 시 유의사항 ⚠️
* postman으로 확인하시면 됩니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
