### PR TITLE
커뮤니티 API의 전반적인 코드 리팩토링을 진행합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
@@ -3,6 +3,8 @@ package org.devridge.api.application.community.project;
 
 import static org.devridge.api.common.util.MemberUtil.toMember;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.devridge.api.common.dto.UserInformation;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
@@ -19,6 +21,9 @@ public class ProjectMapper {
 
         UserInformation userInformation = toMember(member);
 
+        String roles = project.getRoles();
+        List<String> rolesList = Arrays.asList(roles.split("\\s*,\\s*"));
+
         return ProjectDetailResponse.builder()
                 .communityId(project.getId())
                 .userInformation(userInformation)
@@ -29,7 +34,7 @@ public class ProjectMapper {
                 .views(project.getViews() + 1)
                 .createdAt(project.getCreatedAt())
                 .updatedAt(project.getUpdatedAt())
-                .roles(project.getRoles())
+                .roles(rolesList)
                 .meeting(project.getMeeting())
                 .skills(skills)
                 .isRecruiting(project.getIsRecruiting())

--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.devridge.api.common.dto.UserInformation;
 import org.devridge.api.domain.community.dto.request.ProjectRequest;
 import org.devridge.api.domain.community.dto.response.ProjectDetailResponse;
+import org.devridge.api.domain.community.dto.response.ProjectListResponse;
 import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
@@ -59,5 +60,32 @@ public class ProjectMapper {
         }
 
         return builder.build();
+    }
+
+    public List<ProjectListResponse> toProjectListResponses(List<Project> projects) {
+        List<ProjectListResponse> projectListResponses = new ArrayList<>();
+
+        for (Project project : projects) {
+            projectListResponses.add(toProjectListResponse(project));
+        }
+
+        return projectListResponses;
+    }
+
+    public ProjectListResponse toProjectListResponse(Project project) {
+        String roles = project.getRoles();
+        List<String> rolesList = Arrays.asList(roles.split("\\s*,\\s*"));
+
+        return ProjectListResponse.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .content(project.getContent())
+                .likes(project.getLikes())
+                .dislikes(project.getDislikes())
+                .views(project.getViews())
+                .isRecruiting(project.getIsRecruiting())
+                .meeting(project.getMeeting())
+                .roles(rolesList)
+                .build();
     }
 }

--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectService.java
@@ -70,7 +70,8 @@ public class ProjectService {
     }
 
     public List<ProjectListResponse> getAllProject(Long lastId, Pageable pageable) {
-        List<ProjectListResponse> projectListResponses = projectQuerydslRepository.searchByProject(lastId, pageable);
+        List<Project> projects = projectQuerydslRepository.searchByProject(lastId, pageable);
+        List<ProjectListResponse> projectListResponses = projectMapper.toProjectListResponses(projects);
         List<Long> projectIds = toProjectIds(projectListResponses);
         List<ProjectSkill> projectSkills = projectQuerydslRepository.findProjectSkillsInProjectIds(projectIds);
         return groupByProjectId(projectSkills, projectListResponses);

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
@@ -44,8 +44,6 @@ public class StudyMapper {
                     .location(studyRequest.getLocation())
                     .category(studyRequest.getCategory().getValue())
                     .images(images.substring(1, images.length() - 1))
-                    .totalPeople(studyRequest.getTotalPeople())
-                    .currentPeople(studyRequest.getCurrentPeople())
                     .build();
         }
 
@@ -55,8 +53,6 @@ public class StudyMapper {
                 .content(studyRequest.getContent())
                 .location(studyRequest.getLocation())
                 .category(studyRequest.getCategory().getValue())
-                .totalPeople(studyRequest.getTotalPeople())
-                .currentPeople(studyRequest.getCurrentPeople())
                 .build();
     }
 
@@ -68,9 +64,7 @@ public class StudyMapper {
             .title(study.getTitle())
             .content(study.getContent())
             .views(study.getViews())
-            .currentPeople(study.getCurrentPeople())
             .dislikes(study.getDislikes())
-            .totalPeople(study.getTotalPeople())
             .location(study.getLocation())
             .images(study.getImages())
             .build();

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
@@ -31,6 +31,7 @@ public class StudyMapper {
             .views(study.getViews() + 1)
             .createdAt(study.getCreatedAt())
             .updatedAt(study.getUpdatedAt())
+            .location(study.getLocation())
             .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
@@ -32,6 +32,7 @@ public class StudyMapper {
             .createdAt(study.getCreatedAt())
             .updatedAt(study.getUpdatedAt())
             .location(study.getLocation())
+            .category(study.getCategory())
             .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyService.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyService.java
@@ -68,9 +68,7 @@ public class StudyService {
                 request.getContent(),
                 request.getCategory().getValue(),
                 images.substring(1, images.length() - 1),
-                request.getLocation(),
-                request.getTotalPeople(),
-                request.getCurrentPeople()
+                request.getLocation()
             );
             return;
         }
@@ -80,9 +78,7 @@ public class StudyService {
             request.getContent(),
             request.getCategory().getValue(),
             null,
-            request.getLocation(),
-            request.getTotalPeople(),
-            request.getCurrentPeople()
+            request.getLocation()
         );
     }
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/request/StudyRequest.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/request/StudyRequest.java
@@ -12,6 +12,4 @@ public class StudyRequest {
     private StudyCategory category;
     private List<String> images;
     private String location;
-    private Integer totalPeople;
-    private Integer currentPeople;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunitySliceResponse.java
@@ -1,6 +1,7 @@
 package org.devridge.api.domain.community.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -15,7 +16,7 @@ public class CommunitySliceResponse {
     private UserInformation member;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<HashtagResponse> hashtags;
+    private List<HashtagResponse> hashtags = new ArrayList<>();
     private Long scraps;
 
     public void setHashtags(List<HashtagResponse> hashtags) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -31,7 +31,7 @@ public class ProjectDetailResponse {
     @JsonProperty("member")
     private UserInformation userInformation;
 
-    private String roles;
+    private List<String> roles;
 
     private List<String> skills;
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectListResponse.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class ProjectListResponse {
 
     private Long id;
-    private String roles;
+    private List<String> roles;
     private String title;
     private String content;
     private Long likes;

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
@@ -32,10 +32,6 @@ public class StudyDetailResponse {
 
     private String location;
 
-    private Integer totalPeople;
-
-    private Integer currentPeople;
-
     @JsonProperty("member")
     private UserInformation userInformation;
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
@@ -32,6 +32,8 @@ public class StudyDetailResponse {
 
     private String location;
 
+    private String category;
+
     @JsonProperty("member")
     private UserInformation userInformation;
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyListResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyListResponse.java
@@ -20,6 +20,4 @@ public class StudyListResponse {
     private Long dislikes;
     private Long views;
     private String location;
-    private Integer totalPeople;
-    private Integer currentPeople;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Study.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Study.java
@@ -46,31 +46,22 @@ public class Study extends BaseEntity {
 
     private String location;
 
-    @ColumnDefault("0")
-    private Integer totalPeople;
-
-    @ColumnDefault("0")
-    private Integer currentPeople;
-
     @Builder
-    public Study(Member member, String title, String content, String category, String images, String location, Integer totalPeople, Integer currentPeople) {
+    public Study(Member member, String title, String content, String category, String images, String location) {
         this.member = member;
         this.title = title;
         this.content = content;
         this.category = category;
         this.images = images;
         this.location = location;
-        this.totalPeople = totalPeople;
-        this.currentPeople = currentPeople;
     }
 
-    public void updateStudy(String title, String content, String category, String images, String location, Integer totalPeople, Integer currentPeople) {
+    public void updateStudy(String title, String content, String category, String images, String location) {
         this.title = title;
         this.content = content;
         this.category = category;
         this.images = images;
         this.location = location;
-        this.totalPeople = totalPeople;
-        this.currentPeople = currentPeople;
+
     }
 }

--- a/api-module/src/main/java/org/devridge/api/infrastructure/community/project/ProjectQuerydslRepository.java
+++ b/api-module/src/main/java/org/devridge/api/infrastructure/community/project/ProjectQuerydslRepository.java
@@ -1,12 +1,11 @@
 package org.devridge.api.infrastructure.community.project;
 
 import com.querydsl.core.group.GroupBy;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.devridge.api.domain.community.dto.response.ProjectListResponse;
+import org.devridge.api.domain.community.entity.Project;
 import org.devridge.api.domain.community.entity.QProject;
 import org.devridge.api.domain.skill.entity.ProjectSkill;
 import org.devridge.api.domain.skill.entity.QProjectSkill;
@@ -29,7 +28,7 @@ public class ProjectQuerydslRepository {
             .fetch();
     }
 
-    public List<ProjectListResponse> searchByProject(Long lastId, Pageable pageable) {
+    public List<Project> searchByProject(Long lastId, Pageable pageable) {
         return jpaQueryFactory
             .selectFrom(project)
             .leftJoin(project.member)
@@ -40,18 +39,8 @@ public class ProjectQuerydslRepository {
             .orderBy(project.id.desc())
             .limit(pageable.getPageSize() + 1)
             .transform(GroupBy.groupBy(project.id)
-                .list(Projections.fields(
-                    ProjectListResponse.class,
-                    project.id,
-                    project.roles,
-                    project.title,
-                    project.content,
-                    project.likes,
-                    project.dislikes,
-                    project.views,
-                    project.isRecruiting,
-                    project.meeting
-                )));
+                .list(project)
+            );
     }
 
     // no-offset 방식 처리하는 메서드


### PR DESCRIPTION
## Description ✍️
* 자유게시판 상세 조회와 자유게시판 게시글 목록 조회의 hashtag 부분에서 결과가 없을 시 빈 배열을 반환하도록 통일하였습니다.
* 프로젝트의 roles 부분을 리스트로 처리하도록 수정하였습니다.
* 스터디 부분의 데이터 전체 인원과 현재 인원을 삭제하였습니다.
* 스터디 상세 조회의 위치정보 반환값이 정상적으로 반환되지않는 오류를 수정하였습니다.
* 스터디 상세 조회에서 카테고리 값을 반환하지 않는 오류를 수정하였습니다.

## 테스트 시 유의사항 ⚠️
* postman에서 테스트 하시면됩니다

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?