### PR TITLE
Access, Refresh token 모두 쿠키로 통신하도록 변경합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/auth/AuthService.java
+++ b/api-module/src/main/java/org/devridge/api/application/auth/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     public TokenResponse reIssueAccessToken(HttpServletRequest request) {
-        String accessToken = AccessTokenUtil.extractAccessTokenFromRequest(request);
+        String accessToken = AccessTokenUtil.extractAccessTokenFromCookies(request);
 
         if (accessToken == null) {
             throw new UnAuthorizedException();

--- a/api-module/src/main/java/org/devridge/api/common/util/AccessTokenUtil.java
+++ b/api-module/src/main/java/org/devridge/api/common/util/AccessTokenUtil.java
@@ -2,9 +2,9 @@ package org.devridge.api.common.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-
 import org.devridge.api.common.security.auth.AuthProperties;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 public class AccessTokenUtil {
@@ -19,5 +19,18 @@ public class AccessTokenUtil {
             return bearerToken.substring(7).trim();
         }
         return null;
+    }
+
+    public static String extractAccessTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("dev-access".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null; // 해당 이름의 쿠키가 없을 경우 null을 반환
     }
 }

--- a/api-module/src/main/java/org/devridge/api/common/util/JwtUtil.java
+++ b/api-module/src/main/java/org/devridge/api/common/util/JwtUtil.java
@@ -4,17 +4,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-
 import lombok.NoArgsConstructor;
-
+import org.devridge.api.common.security.auth.AuthProperties;
 import org.devridge.api.domain.member.entity.Member;
 import org.devridge.api.domain.sociallogin.entity.OAuth2Member;
-import org.devridge.api.common.security.auth.AuthProperties;
-
 import org.springframework.http.ResponseCookie;
 
 import java.security.Key;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +64,7 @@ public class JwtUtil {
     }
 
     public static ResponseCookie generateRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from("devridge", refreshToken)
+        return ResponseCookie.from("dev-refresh", refreshToken)
                 .httpOnly(true)
                 .sameSite("None")
                 .secure(true)
@@ -78,12 +74,22 @@ public class JwtUtil {
     }
 
     public static ResponseCookie generateRefreshTokenCookie(String refreshToken, long time) {
-        return ResponseCookie.from("devridge", refreshToken)
+        return ResponseCookie.from("dev-refresh", refreshToken)
                 .httpOnly(true)
                 .sameSite("None")
                 .secure(true)
                 .path("/")
                 .maxAge(time)
+                .build();
+    }
+
+    public static ResponseCookie generateAccessTokenCookie(String accessToken) {
+        return ResponseCookie.from("dev-access", accessToken)
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .path("/")
+                .maxAge(ACCESS_TOKEN_VALIDITY_TIME)
                 .build();
     }
 
@@ -102,6 +108,7 @@ public class JwtUtil {
     // 인가 필터 - access token 만료 시 refreshToken의 유효성을 쉽게 조회하기 위해 refresh token id도 함께 넣어준다
     private static Map<String, Object> createAccessTokenClaims(Member member, Long refreshTokenId) {
         Map<String, Object> map = new HashMap<>();
+        map.put("memberId", member.getId());
         map.put("memberEmail", member.getEmail());
         map.put("provider", member.getProvider());
         map.put("refreshTokenId", refreshTokenId);

--- a/api-module/src/main/java/org/devridge/api/common/util/RefreshTokenUtil.java
+++ b/api-module/src/main/java/org/devridge/api/common/util/RefreshTokenUtil.java
@@ -1,9 +1,46 @@
 package org.devridge.api.common.util;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import org.devridge.api.common.security.auth.AuthProperties;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 
 public class RefreshTokenUtil {
     public static Long getRefreshTokenIdFromClaims(Claims claims) {
         return ((Integer)claims.get("refreshTokenId")).longValue();
+    }
+
+    public static Claims getClaimsFromRefreshToken(String refreshToken) {
+        return Jwts.parserBuilder().setSigningKey(AuthProperties.getRefreshSecret()).build().parseClaimsJws(refreshToken).getBody();
+    }
+
+    public static String extractRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("dev-refresh".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean checkIfRefreshTokenValid(String refreshToken) {
+        Claims claims = null;
+
+        try {
+            claims = getClaimsFromRefreshToken(refreshToken);
+        } catch (ExpiredJwtException e) { // 리프레시 토큰 만료
+            return false;
+        } catch (MalformedJwtException e) { // 위변조 검사
+            return false;
+        }
+        return true;
     }
 }

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/auth/SocialLoginController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/auth/SocialLoginController.java
@@ -33,16 +33,14 @@ public class SocialLoginController {
            return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
        }
 
-       return ResponseEntity.status(HttpStatus.OK).body(
-               new TokenResponse(data.getToken())
-       );
+       return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/signUp")
     public ResponseEntity<TokenResponse> createMemberAndLogin(
             @RequestBody @Valid SocialLoginSignUp socialLoginRequest, HttpServletResponse response)
     {
-        TokenResponse result = socialLoginService.signUpAndLogin(socialLoginRequest, response);
-        return ResponseEntity.ok().body(result);
+        socialLoginService.signUpAndLogin(socialLoginRequest, response);
+        return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## Description ✍️
* Access, Refresh token 모두 쿠키로 통신하도록 변경합니다.
* 엑세스 토큰이 만료되면 서버에서 자동으로 발급해 쿠키에 실어보냅니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?