### PR TITLE
커뮤니티에 해당하는 게시글 상세조회 api의 응답dto에 scrap수와 comment수를 추가합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/community/freeboard/CommunityMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/freeboard/CommunityMapper.java
@@ -28,6 +28,8 @@ public class CommunityMapper {
                 .views(community.getViews() + 1)
                 .createdAt(community.getCreatedAt())
                 .updatedAt(community.getUpdatedAt())
+                .scraps(Long.valueOf(community.getScraps().size()))
+                .comments(Long.valueOf(community.getComments().size()))
                 .build();
     }
 

--- a/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/project/ProjectMapper.java
@@ -32,6 +32,8 @@ public class ProjectMapper {
                 .content(project.getContent())
                 .likes(project.getLikes())
                 .dislikes(project.getDislikes())
+                .comments(Long.valueOf(project.getComments().size()))
+                .scraps(Long.valueOf(project.getScraps().size()))
                 .views(project.getViews() + 1)
                 .createdAt(project.getCreatedAt())
                 .updatedAt(project.getUpdatedAt())

--- a/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/community/study/StudyMapper.java
@@ -22,18 +22,20 @@ public class StudyMapper {
         UserInformation userInformation = toMember(member);
 
         return StudyDetailResponse.builder()
-            .studyId(study.getId())
-            .userInformation(userInformation)
-            .title(study.getTitle())
-            .content(study.getContent())
-            .likes(study.getLikes())
-            .dislikes(study.getDislikes())
-            .views(study.getViews() + 1)
-            .createdAt(study.getCreatedAt())
-            .updatedAt(study.getUpdatedAt())
-            .location(study.getLocation())
-            .category(study.getCategory())
-            .build();
+                .studyId(study.getId())
+                .userInformation(userInformation)
+                .title(study.getTitle())
+                .content(study.getContent())
+                .likes(study.getLikes())
+                .dislikes(study.getDislikes())
+                .scraps(Long.valueOf(study.getScraps().size()))
+                .comments(Long.valueOf(study.getComments().size()))
+                .views(study.getViews() + 1)
+                .createdAt(study.getCreatedAt())
+                .updatedAt(study.getUpdatedAt())
+                .location(study.getLocation())
+                .category(study.getCategory())
+                .build();
     }
 
     public Study toStudy(Member member, StudyRequest studyRequest) {

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/CommunityDetailResponse.java
@@ -27,6 +27,10 @@ public class CommunityDetailResponse {
 
     private Long dislikes;
 
+    private Long scraps;
+
+    private Long comments;
+
     @JsonProperty("member")
     private UserInformation userInformation;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/ProjectDetailResponse.java
@@ -28,6 +28,10 @@ public class ProjectDetailResponse {
 
     private Long dislikes;
 
+    private Long scraps;
+
+    private Long comments;
+
     @JsonProperty("member")
     private UserInformation userInformation;
 

--- a/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/dto/response/StudyDetailResponse.java
@@ -30,6 +30,10 @@ public class StudyDetailResponse {
 
     private Long dislikes;
 
+    private Long scraps;
+
+    private Long comments;
+
     private String location;
 
     private String category;

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Project.java
@@ -58,6 +58,12 @@ public class Project extends BaseEntity {
     @ColumnDefault("true")
     private Boolean isRecruiting;
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    private List<ProjectComment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    private List<ProjectScrap> scraps = new ArrayList<>();
+
     @Builder
     public Project(Member member, String title, String content, String roles, String images, String meeting, Boolean isRecruiting) {
         this.member = member;

--- a/api-module/src/main/java/org/devridge/api/domain/community/entity/Study.java
+++ b/api-module/src/main/java/org/devridge/api/domain/community/entity/Study.java
@@ -1,9 +1,13 @@
 package org.devridge.api.domain.community.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +49,12 @@ public class Study extends BaseEntity {
     private String images;
 
     private String location;
+
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<StudyComment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<StudyScrap> scraps = new ArrayList<>();
 
     @Builder
     public Study(Member member, String title, String content, String category, String images, String location) {


### PR DESCRIPTION
## Description ✍️
* 자유게시글 상세조회 응답 dto에 scrap수와 comment수를 추가하였습니다.
* 프로젝트 상세조회 응답 dto에 scrap수와 comment수를 추가하였습니다.
* 스터디 상세조회 응답 dto에 scrap수와 comment수를 추가하였습니다.

## Merge 전 체크 리스트 ✅
- [x] Backend 컨벤션을 잘 지켰나요?
- [x] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?