### PR TITLE
기획 수정에 따른 커피챗 응답 데이터를 수정합니다.

### DIFF
--- a/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatMapper.java
@@ -106,6 +106,8 @@ public class CoffeeChatMapper {
             .id(request.getId())
             .member(fromMember)
             .message(request.getMessage())
+            .createdAt(request.getCreatedAt())
+            .updatedAt(request.getUpdatedAt())
             .build();
     }
 
@@ -127,7 +129,7 @@ public class CoffeeChatMapper {
                     .message(request.getMessage())
                     .status(status)
                     .createdAt(request.getCreatedAt())
-                    .createdAt(request.getUpdatedAt())
+                    .updatedAt(request.getUpdatedAt())
                     .build()
             );
         }

--- a/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatMapper.java
+++ b/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatMapper.java
@@ -101,7 +101,12 @@ public class CoffeeChatMapper {
 
     public GetCoffeeChatRequestResponse toGetCoffeeChatRequest(CoffeeChatRequest request) {
         UserInformation fromMember = toMember(request.getFromMember());
-        return new GetCoffeeChatRequestResponse(request.getId(), fromMember, request.getMessage());
+
+        return GetCoffeeChatRequestResponse.builder()
+            .id(request.getId())
+            .member(fromMember)
+            .message(request.getMessage())
+            .build();
     }
 
     public GetAllCoffeeChatRequest toGetSendCoffeeChatRequests(List<CoffeeChatRequest> requests) {
@@ -116,12 +121,14 @@ public class CoffeeChatMapper {
             String status = this.getStatus(request.getIsSuccess());
 
             coffeeChatRequests.add(
-                new GetCoffeeChatRequestResponse(
-                    request.getId(),
-                    toMember(request.getToMember()),
-                    request.getMessage(),
-                    status
-                )
+                GetCoffeeChatRequestResponse.builder()
+                    .id(request.getId())
+                    .member(toMember(request.getToMember()))
+                    .message(request.getMessage())
+                    .status(status)
+                    .createdAt(request.getCreatedAt())
+                    .createdAt(request.getUpdatedAt())
+                    .build()
             );
         }
 
@@ -150,11 +157,13 @@ public class CoffeeChatMapper {
             }
 
             coffeeChatRequests.add(
-                new GetCoffeeChatRequestResponse(
-                    request.getId(),
-                    toMember(request.getFromMember()),
-                    request.getMessage()
-                )
+                GetCoffeeChatRequestResponse.builder()
+                    .id(request.getId())
+                    .member(toMember(request.getFromMember()))
+                    .message(request.getMessage())
+                    .createdAt(request.getCreatedAt())
+                    .updatedAt(request.getUpdatedAt())
+                    .build()
             );
         }
 

--- a/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatService.java
+++ b/api-module/src/main/java/org/devridge/api/application/coffeechat/CoffeeChatService.java
@@ -11,6 +11,7 @@ import org.devridge.api.domain.coffeechat.dto.type.YesOrNo;
 import org.devridge.api.domain.coffeechat.entity.ChatMessage;
 import org.devridge.api.domain.coffeechat.entity.ChatRoom;
 import org.devridge.api.domain.coffeechat.entity.CoffeeChatRequest;
+import org.devridge.api.domain.coffeechat.exception.NoCancelCoffeeChatRequestException;
 import org.devridge.api.infrastructure.coffeechat.ChatMessageRepository;
 import org.devridge.api.infrastructure.coffeechat.ChatRoomRepository;
 import org.devridge.api.infrastructure.coffeechat.CoffeeChatQuerydslRepository;
@@ -185,6 +186,19 @@ public class CoffeeChatService {
         ChatMessage message = chatMessageRepository.findById(messageId).orElseThrow(DataNotFoundException::new);
 
         chatMessageRepository.deleteById(messageId);
+    }
+
+    public void deleteCoffeeChatRequest(Long requestId) {
+        CoffeeChatRequest coffeeChatRequest = coffeeChatRequestRepository
+                .findById(requestId)
+                .orElseThrow(DataNotFoundException::new);
+
+        /* 대기 상태인 요청만 취소 가능 */
+        if (coffeeChatRequest.getIsSuccess() != null) {
+            throw new NoCancelCoffeeChatRequestException(409, "이미 처리된 요청은 취소할 수 없습니다.");
+        }
+
+        coffeeChatRequestRepository.delete(coffeeChatRequest);
     }
 
     private Member getMember(Long memberId) {

--- a/api-module/src/main/java/org/devridge/api/domain/coffeechat/dto/response/GetCoffeeChatRequestResponse.java
+++ b/api-module/src/main/java/org/devridge/api/domain/coffeechat/dto/response/GetCoffeeChatRequestResponse.java
@@ -2,11 +2,17 @@ package org.devridge.api.domain.coffeechat.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import org.devridge.api.common.dto.UserInformation;
 
+import java.time.LocalDateTime;
+
 @Getter
+@Builder
+@AllArgsConstructor
 public class GetCoffeeChatRequestResponse {
 
     private Long id;
@@ -16,16 +22,6 @@ public class GetCoffeeChatRequestResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String status;
 
-    public GetCoffeeChatRequestResponse(Long id, UserInformation member, String message) {
-        this.id = id;
-        this.member = member;
-        this.message = message;
-    }
-
-    public GetCoffeeChatRequestResponse(Long id, UserInformation member, String message, String status) {
-        this.id = id;
-        this.member = member;
-        this.message = message;
-        this.status = status;
-    }
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/api-module/src/main/java/org/devridge/api/domain/coffeechat/exception/NoCancelCoffeeChatRequestException.java
+++ b/api-module/src/main/java/org/devridge/api/domain/coffeechat/exception/NoCancelCoffeeChatRequestException.java
@@ -1,0 +1,10 @@
+package org.devridge.api.domain.coffeechat.exception;
+
+import org.devridge.api.common.exception.common.BaseException;
+
+public class NoCancelCoffeeChatRequestException extends BaseException {
+
+    public NoCancelCoffeeChatRequestException(int code, String message) {
+        super(code, message);
+    }
+}

--- a/api-module/src/main/java/org/devridge/api/presentation/controller/coffeechat/CoffeeChatController.java
+++ b/api-module/src/main/java/org/devridge/api/presentation/controller/coffeechat/CoffeeChatController.java
@@ -113,4 +113,14 @@ public class CoffeeChatController {
         coffeeChatService.deleteChatMessage(roomId, messageId);
         return ResponseEntity.ok().build();
     }
+
+    /**
+     * 내가 보낸 채팅방 요청 삭제
+     * @return
+     */
+    @DeleteMapping("/requests/{requestId}")
+    public ResponseEntity<Void> cancelCoffeeChatRequest(@PathVariable Long requestId) {
+        coffeeChatService.deleteCoffeeChatRequest(requestId);
+        return ResponseEntity.ok().build();
+    }
 }


### PR DESCRIPTION
## Description ✍️
* 커피챗 정보 조회 시 createdAt, updatedAt을 추가합니다.
* 메세지에는 이미 createdAt, updatedAt이 있어 별도로 추가하지는 않았습니다.
* 내가 보낸 커피챗 요청에 대해 취소 기능을 추가했습니다.

## Screen Shot 📷
응답 결과는 아래와 같습니다.
```
{
    "coffeeChatRequests": [
        {
            "id": 4,
            "member": {
                "id": 211,
                "nickname": "하우돈",
                "profileImageUrl": "member/ce8267a8-5b27-449c-ad62-c67f77ceed51.png",
                "introduction": "안녕하세요"
            },
            "message": "안녕하세요! 저는 정윤조입니다.",
            "status": "승인",
            "createdAt": "2024-03-02T00:19:42",
            "updatedAt": "2024-03-02T23:56:47"
        }
    ],
    "noReadCount": 1
}
```

## 테스트 시 유의사항 ⚠️
* 대기 중인 커피챗 요청 삭제 엔드포인트는 `DELETE http://localhost:8080/api/coffee-chat/requests/{requestId}` 입니다.
## Merge 전 체크 리스트 ✅
- [ ] Backend 컨벤션을 잘 지켰나요?
- [ ] 오류 없이 해당 기능이 잘 동작되나요?
- [ ] 모든 리뷰어의 승인을 받았나요?
